### PR TITLE
`DesignSystem` UIView CornerRadius 함수 추가

### DIFF
--- a/DesignSystem/Sources/Extensions/View+Extension.swift
+++ b/DesignSystem/Sources/Extensions/View+Extension.swift
@@ -1,0 +1,32 @@
+//
+//  View+Extension.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/10/18.
+//
+
+import UIKit
+
+public extension UIView {
+  
+  /// UIView의 CornerRadius를 추가합니다.
+  /// - .all: 모든 모서리에 CornerRadius를 적용합니다.
+  /// - .onlyTop: 상단 모서리에 CornerRadius를 적용합니다.
+  /// - .onlyBottom: 하단 모서리에 CornerRadius를 적용합니다.
+  /// - parameter radius: CGFloat
+  /// - parameter edge: ViewCornerRadiuseType
+  func makeCorderRadius(
+    _ radius: CGFloat,
+    edge type: ViewCornerRadiusType = .all
+  ) {
+    layer.masksToBounds = true
+    layer.cornerRadius = radius
+    switch type {
+    case .onlyTop:
+      layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    case .onlyBottom:
+      layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+    default: break
+    }
+  }
+}

--- a/DesignSystem/Sources/Types/ViewCornerRadiusType.swift
+++ b/DesignSystem/Sources/Types/ViewCornerRadiusType.swift
@@ -1,0 +1,14 @@
+//
+//  ViewCornerRadiusType.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/10/18.
+//
+
+import Foundation
+
+public enum ViewCornerRadiusType {
+  case all
+  case onlyTop
+  case onlyBottom
+}


### PR DESCRIPTION
### 배경
UI Component 내, CornerRadius 추가 시, 쉽게 적용할 수 있도록 별도 함수 적용

### 적용사항
1. ViewCornerRadiusType
> all: 모든 모서리에 cornerRadius 적용
> onlyTop: 상단 모서리에 cornerRadius 적용
> onlyBottom: 하단 모서리에 cornerRadius 적용

2. makeCorderRadius(_ radius: CGFloat, edge type: ViewCornerRadiusType = .all)
> UIView extension내 적용된 함수로, `radius`와 `edge`를 통해, cornerRadius 적용
> edge type은 기본 `.all`로 적용

### 사용 예시
``` swift
import DesignSystem

class ViewController: UIViewController {
  private let mainLabel: UILabel = UILabel()

  // 코드 생략
  
  private func setupMainLabel() {
    // 코드 생략
    mainLabel.makeCorderRadius(8, edge: .onlyTop)
  }
}
```