### PR TITLE
`DesignSystem` 'email', 'password' 이미지 렌더링 모드 `Template`로 변경

### DIFF
--- a/ResourceKit/Resources/Image/Image.xcassets/email.imageset/Contents.json
+++ b/ResourceKit/Resources/Image/Image.xcassets/email.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/ResourceKit/Resources/Image/Image.xcassets/password.imageset/Contents.json
+++ b/ResourceKit/Resources/Image/Image.xcassets/password.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
### 배경
외부에서 아이콘 이미지 색상 변경이 필요한 경우가 생김

### 변경사항
현재 디자인에서 보이는 경우만 변경
`email`, `password` 두 이미지의 rendering 모드를 `Template`으로 변경

### 결과
이미지 색상을 외부에서 변경 가능