### PR TITLE
`Design system` UIView에 'makeBorder' 및 'makeBorderWithCornerRadius' 함수 추가

### DIFF
--- a/DesignSystem/Sources/Extensions/View+Extension.swift
+++ b/DesignSystem/Sources/Extensions/View+Extension.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import ResourceKit
+
 public extension UIView {
   
   /// UIView의 CornerRadius를 추가합니다.
@@ -15,7 +17,7 @@ public extension UIView {
   /// - .onlyBottom: 하단 모서리에 CornerRadius를 적용합니다.
   /// - parameter radius: CGFloat
   /// - parameter edge: ViewCornerRadiuseType
-  func makeCorderRadius(
+  func makeCornerRadius(
     _ radius: CGFloat,
     edge type: ViewCornerRadiusType = .all
   ) {
@@ -30,4 +32,30 @@ public extension UIView {
     }
   }
   
+  /// UIView의 Border를 추가합니다.
+  /// - parameter width: CGFloat
+  /// - parameter color: UIColor
+  func makeBorder(
+    borderWidth: CGFloat = 1.0,
+    borderColor: UIColor = .AppColor.appGrey70
+  ) {
+    layer.masksToBounds = true
+    layer.borderWidth = borderWidth
+    layer.borderColor = borderColor.cgColor
+  }
+  
+  /// UIView의 CornerRadius와 Border를 함께 추가합니다.
+  /// - parameter radius: CGFloat
+  /// - parameter width: CGFloat
+  /// - parameter color: UIColor
+  func makeCornerRadiusWithBorder(
+    _ radius: CGFloat,
+    borderWidth: CGFloat = 1.0,
+    borderColor: UIColor = .AppColor.appGrey70
+  ) {
+    layer.masksToBounds = true
+    layer.cornerRadius = radius
+    layer.borderWidth = borderWidth
+    layer.borderColor = borderColor.cgColor
+  }
 }

--- a/DesignSystem/Sources/TextFields/IconBorderTextField.swift
+++ b/DesignSystem/Sources/TextFields/IconBorderTextField.swift
@@ -86,7 +86,6 @@ public class IconBorderTextField: UIView {
     super.init(frame: .zero)
     self.setupSubViews()
     self.setupConfiguration()
-    self.setupCornerRadiusWithBorder()
     self.setupBindings()
   }
   
@@ -134,6 +133,8 @@ private extension IconBorderTextField {
   
   /// IconBorderTextField의 타입에 따른 이미지를 정의합니다.
   func setupConfiguration() {
+    makeCornerRadiusWithBorder(16)
+    
     iconImageView.image = type.iconImage
     
     textField.keyboardType = keyboardType
@@ -141,13 +142,6 @@ private extension IconBorderTextField {
     textField.textColor = textFieldColor
     textField.tintColor = textFieldColor
     textField.font = textFieldFont
-  }
-  
-  /// IconBorderTextField의 CornerRadius 및 Border를 정의합니다.
-  func setupCornerRadiusWithBorder() {
-    makeCorderRadius(16)
-    layer.borderColor = UIColor.AppColor.appGrey70.cgColor
-    layer.borderWidth = 1
   }
   
   func setupBindings() {


### PR DESCRIPTION
### 배경
cornerRadius와 border를 함께 적용해야 되는 상황이 생기
두 개의 함수를 각각 선언해 적용할 수 있지만, 내부에서 'layer.maskToBounds'가 겹치는게 별로인 것 같아
별도의 함수로 생성

### 변경사항
1. makeBorder 함수
> borderWidth: 기본값 1.0 으로 설정
> borderColor: 기본값 .AppColor.appGrey70으로 설정

2. makeCornerRadiusWithBorder 함수
>  radius: CGFloat
> borderWidth: 기본값 1.0 으로 설정
> borderColor: 기본값 .AppColor.appGrey70으로 설정

### 적용 방법
``` swift
import DesignSystem

class ViewController: UIViewController {
  private let borderRectangle = UIView()
  private let roundBorderRectangle = UIView()

  // 코드 생략

  private func setupViews() {
    borderRectangle.makeBorder()
    roundBorderRectangle.makeCornerRadiusWithBorder(10)
  }
}
```