### PR TITLE
`DesignSystem` Button cornerRadius 적용 부분 extension 함수로 수정

### DIFF
--- a/DesignSystem/Sources/Buttons/DefaultButton.swift
+++ b/DesignSystem/Sources/Buttons/DefaultButton.swift
@@ -57,7 +57,6 @@ public class DefaultButton: UIButton {
     self.isEnabled = initEnableState
     self.setupConfiguration()
     self.setupFrame()
-    self.setupCornerRadius()
   }
   
   required init?(coder: NSCoder) {
@@ -88,6 +87,9 @@ private extension DefaultButton {
   func setupConfiguration() {
     setTitle(title, for: .normal)
     titleLabel?.font = buttonFont
+    
+    makeCornerRadius(metric.buttonRadius)
+    
     if isEnabled { setupEnableButtonState() }
     else { setupDisableButtonState() }
   }
@@ -97,12 +99,6 @@ private extension DefaultButton {
     snp.makeConstraints { make in
       make.height.equalTo(metric.buttonHeight)
     }
-  }
-  
-  /// DefatulButton의 cornerRadius를 설정합니다.
-  func setupCornerRadius() {
-    layer.masksToBounds = true
-    layer.cornerRadius = metric.buttonRadius
   }
   
   /// DefatulButton의 'isEnable = true'의 상태를 정의합니다.

--- a/DesignSystem/Sources/Buttons/SocialLoginButton.swift
+++ b/DesignSystem/Sources/Buttons/SocialLoginButton.swift
@@ -44,7 +44,6 @@ public class SocialLoginButton: UIButton {
     super.init(frame: .zero)
     self.setupConfiguration()
     self.setupFrame()
-    self.setupCornerRadius()
   }
   
   required init?(coder: NSCoder) {
@@ -67,6 +66,8 @@ private extension SocialLoginButton {
     case .email:
       setImage(.AppImage.emailLogin, for: .normal)
     }
+    
+    makeCornerRadius(metric.buttonRadius)
   }
   
   /// LoginButton의 Frame을 정의합니다.
@@ -74,10 +75,5 @@ private extension SocialLoginButton {
     snp.makeConstraints { make in
       make.size.equalTo(metric.buttonSize)
     }
-  }
-  
-  func setupCornerRadius() {
-    layer.masksToBounds = true
-    layer.cornerRadius = metric.buttonRadius
   }
 }


### PR DESCRIPTION
### 배경
DesignSystem 내 버튼의 경우 별도로 cornerRadius를 적용하고 있었음.
즉, 기존 View+extension 함수가 적용되지 않음.

### 수정사항
View+Extension의 `makeCornerRadius` 함수로 수정

### 결과
기존과 동일하게 cornerRadius 적용 완료