### PR TITLE
`DesignSystem` UIViewController에서 keyboard높이를 가져오기 위한 `keyboardHeight` 타입 프로퍼티 생성

### DIFF
--- a/DesignSystem/Sources/Extensions/UIViewController+Extension.swift
+++ b/DesignSystem/Sources/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,46 @@
+//
+//  UIViewController+Extension.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/10/30.
+//
+
+import UIKit
+
+// MARK: - 키보드 관련 UIViewController Extension
+public extension UIViewController {
+	
+	/// UIViewController에서 keyboardHeight가 필요한 경우 접근할 수 있는 타입 프로퍼티입니다.
+	static var keyboardHeight: CGFloat = 0.0
+	
+	/// viewDidLoad에서 해당 함수를 선언합니다.
+	/// 선언 후, Self.keyboardHeight 변수에 접근할 경우, 현재 화면에서 키보드 높이를 가져올 수 있습니다.
+	func registerKeyboardObserver() {
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(keyboardWillShow),
+			name: UIResponder.keyboardWillShowNotification,
+			object: nil
+		)
+		
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(keyboardWillHide),
+			name: UIResponder.keyboardWillHideNotification,
+			object: nil
+		)
+	}
+	
+	@objc private func keyboardWillShow(notification: NSNotification) {
+		if let keyboardFrame: NSValue = notification.userInfo?[
+			UIResponder.keyboardFrameEndUserInfoKey
+		] as? NSValue {
+			let keyboardRectangle = keyboardFrame.cgRectValue
+			Self.keyboardHeight = keyboardRectangle.height
+		}
+	}
+	
+	@objc private func keyboardWillHide(notification: NSNotification) {
+		Self.keyboardHeight = 0.0
+	}
+}


### PR DESCRIPTION
### 배경
키보드 높이에 따른 애니메이션 등, UIViewController에서 키보드 높이를 필요로 하는 경우가 생김

### 적용 사항
UIViewController extension을 통해, Keyboard높이를 타입 프로퍼티로 관리
이때 Notification 등록을 위해, viewDidLoad에서 `registerKeyboardObserver()` 메소드 선언

### 적용 예시
``` swift
import DesignSystem

final class ViewController: UIViewController {

  override func viewDidLoad() {
    super.viewDidLoad()
    registerKeyboardObserver()
  }
  
  // 코드 생략
  
  private func getCurrentKeyboardHeight() {
    print(Self.keyboardHeight)
  }
}

```

### 결과
키보드 존재 유무에 따라 옳바른 높이 가져옴
