### PR TITLE
`DesignSystem` 내부 상수 정의 struct -> enum으로 변경

### DIFF
--- a/DesignSystem/Sources/Buttons/DefaultButton.swift
+++ b/DesignSystem/Sources/Buttons/DefaultButton.swift
@@ -21,6 +21,11 @@ public class DefaultButton: UIButton {
     static let buttonHeight: CGFloat = 48
     static let buttonRadius: CGFloat = 16
   }
+	
+	// MARK: Font
+	private enum Font {
+		static let buttonFont: UIFont = .AppFont.Bold_14
+	}
   
   // MARK: COLORSET
   /// DefaultButton의 색상 요소를 정의합니다.
@@ -37,7 +42,6 @@ public class DefaultButton: UIButton {
   private let initEnableState: Bool
   
   // MARK: PROPERTY
-  private let buttonFont: UIFont
   private let disposeBag: DisposeBag
   
   // MARK: INITIALIZE
@@ -46,7 +50,6 @@ public class DefaultButton: UIButton {
     initEnableState: Bool = true
   ) {
     self.title = title
-    self.buttonFont = .AppFont.Bold_14
     self.disposeBag = .init()
     self.initEnableState = initEnableState
     super.init(frame: .zero)
@@ -82,7 +85,7 @@ private extension DefaultButton {
   /// DefatulButton의 기본 상태를 정의합니다.
   func setupConfiguration() {
     setTitle(title, for: .normal)
-    titleLabel?.font = buttonFont
+		titleLabel?.font = Font.buttonFont
     
     makeCornerRadius(Metric.buttonRadius)
     

--- a/DesignSystem/Sources/Buttons/DefaultButton.swift
+++ b/DesignSystem/Sources/Buttons/DefaultButton.swift
@@ -17,19 +17,19 @@ public class DefaultButton: UIButton {
   
   // MARK: METRIC
   /// DefaultButton의 크기 요소를 정의합니다.
-  private struct Metric {
-    let buttonHeight: CGFloat = 48
-    let buttonRadius: CGFloat = 16
+  private enum Metric {
+    static let buttonHeight: CGFloat = 48
+    static let buttonRadius: CGFloat = 16
   }
   
   // MARK: COLORSET
   /// DefaultButton의 색상 요소를 정의합니다.
-  private struct ColorSet {
-		let enableTitleColor: UIColor = .AppColor.appWhite
-    let enableBackgroundColor: UIColor = .AppColor.appPrimary
-		let disableTitleColor: UIColor = .AppColor.appWhite
-    let disableBackgroundColor: UIColor = .AppColor.appGrey70
-    let pressedColor: UIColor = .AppColor.appPrimary.withAlphaComponent(0.75)
+  private enum ColorSet {
+		static let enableTitleColor: UIColor = .AppColor.appWhite
+    static let enableBackgroundColor: UIColor = .AppColor.appPrimary
+		static let disableTitleColor: UIColor = .AppColor.appWhite
+    static let disableBackgroundColor: UIColor = .AppColor.appGrey70
+    static let pressedColor: UIColor = .AppColor.appPrimary.withAlphaComponent(0.75)
   }
   
   // MARK: INPUT PROPERTY
@@ -37,8 +37,6 @@ public class DefaultButton: UIButton {
   private let initEnableState: Bool
   
   // MARK: PROPERTY
-  private let metric: Metric
-  private let colorSet: ColorSet
   private let buttonFont: UIFont
   private let disposeBag: DisposeBag
   
@@ -48,8 +46,6 @@ public class DefaultButton: UIButton {
     initEnableState: Bool = true
   ) {
     self.title = title
-    self.metric = .init()
-    self.colorSet = .init()
     self.buttonFont = .AppFont.Bold_14
     self.disposeBag = .init()
     self.initEnableState = initEnableState
@@ -88,7 +84,7 @@ private extension DefaultButton {
     setTitle(title, for: .normal)
     titleLabel?.font = buttonFont
     
-    makeCornerRadius(metric.buttonRadius)
+    makeCornerRadius(Metric.buttonRadius)
     
 		if isEnabled {
 			setupEnableButtonState()
@@ -100,29 +96,29 @@ private extension DefaultButton {
   /// DefatulButton의 고정 높이를 지정합니다.
   func setupFrame() {
     snp.makeConstraints { make in
-      make.height.equalTo(metric.buttonHeight)
+      make.height.equalTo(Metric.buttonHeight)
     }
   }
   
   /// DefatulButton의 'isEnable = true'의 상태를 정의합니다.
   func setupEnableButtonState() {
-    backgroundColor = colorSet.enableBackgroundColor
-    setTitleColor(colorSet.enableTitleColor, for: .normal)
+    backgroundColor = ColorSet.enableBackgroundColor
+    setTitleColor(ColorSet.enableTitleColor, for: .normal)
   }
   
   /// DefatulButton의 'isEnable = false'의 상태를 정의합니다.
   func setupDisableButtonState() {
-    backgroundColor = colorSet.disableBackgroundColor
-    setTitleColor(colorSet.disableTitleColor, for: .disabled)
+    backgroundColor = ColorSet.disableBackgroundColor
+    setTitleColor(ColorSet.disableTitleColor, for: .disabled)
   }
   
   /// DefatulButton의 'isHighlighted = true'의 상태를 정의합니다.
   func setupStartPressingButton() {
-    backgroundColor = colorSet.pressedColor
+    backgroundColor = ColorSet.pressedColor
   }
   
   /// DefatulButton의 'isHighlighted = false'의 상태를 정의합니다.
   func setupEndPressingButton() {
-    backgroundColor = colorSet.enableBackgroundColor
+    backgroundColor = ColorSet.enableBackgroundColor
   }
 }

--- a/DesignSystem/Sources/Buttons/SocialLoginButton.swift
+++ b/DesignSystem/Sources/Buttons/SocialLoginButton.swift
@@ -24,23 +24,19 @@ public class SocialLoginButton: UIButton {
   
   // MARK: METRIC
   /// LoginButton의 크기 요소를 정의합니다.
-  private struct Metric {
-    let buttonSize: CGFloat = 54
-    let buttonRadius: CGFloat = 27
+  private enum Metric {
+    static let buttonSize: CGFloat = 54
+    static let buttonRadius: CGFloat = 27
   }
   
   // MARK: INPUT PROPERTY
   private let type: SocialLoginType
-  
-  // MARK: PROPERTY
-  private let metric: Metric
   
   // MARK: INITIALIZE
   public init(
     _ type: SocialLoginType
   ) {
     self.type = type
-    self.metric = .init()
     super.init(frame: .zero)
     self.setupConfiguration()
     self.setupFrame()
@@ -67,13 +63,13 @@ private extension SocialLoginButton {
       setImage(.AppImage.emailLogin, for: .normal)
     }
     
-    makeCornerRadius(metric.buttonRadius)
+    makeCornerRadius(Metric.buttonRadius)
   }
   
   /// LoginButton의 Frame을 정의합니다.
   func setupFrame() {
     snp.makeConstraints { make in
-      make.size.equalTo(metric.buttonSize)
+      make.size.equalTo(Metric.buttonSize)
     }
   }
 }

--- a/DesignSystem/Sources/NavigationBar/NavigationBar.swift
+++ b/DesignSystem/Sources/NavigationBar/NavigationBar.swift
@@ -45,15 +45,24 @@ public class NavigationBar: UIView {
 		static let navigationTitleBottomMargin: CGFloat = -15
 	}
 	
+	// MARK: Font
+	private enum Font {
+		static let navigationTitleFont: UIFont = .AppFont.Bold_18
+	}
+	
+	// MARK: ColorSet
+	private enum ColorSet {
+		static let backgroundColor: UIColor = .AppColor.appWhite
+		static let navigationTitleColor: UIColor = .AppColor.appBlack
+		static let navigationLeftButtonColor: UIColor = .AppColor.appBlack
+	}
+	
 	// MARK: - OUTPUT
 	public var didTapLeftButton: (() -> Void)?
 	
 	// MARK: - PROPERTY
 	private let navigationType: NavigationType
 	private let navigationTitle: String
-	private let navigationLeftButtonColor: UIColor
-	private let navigationTitleFont: UIFont
-	private let navigationTitleColor: UIColor
 	private let disposeBag: DisposeBag
 	
 	private let navigationLeftButton: UIButton = UIButton(type: .system)
@@ -66,9 +75,6 @@ public class NavigationBar: UIView {
 	) {
 		self.navigationType = navigationType
 		self.navigationTitle = title
-		self.navigationLeftButtonColor = .AppColor.appBlack
-		self.navigationTitleFont = .AppFont.Bold_18
-		self.navigationTitleColor = .AppColor.appBlack
 		self.disposeBag = .init()
 		super.init(frame: .zero)
 		setupConfigure()
@@ -88,14 +94,14 @@ public class NavigationBar: UIView {
 
 private extension NavigationBar {
 	func setupConfigure() {
-		backgroundColor = .AppColor.appWhite
+		backgroundColor = ColorSet.backgroundColor
 		
 		navigationLeftButton.setImage(navigationType.buttonImage, for: .normal)
-		navigationLeftButton.tintColor = navigationLeftButtonColor
+		navigationLeftButton.tintColor = ColorSet.navigationLeftButtonColor
 		
 		navigationTitleLabel.text = navigationTitle
-		navigationTitleLabel.font = navigationTitleFont
-		navigationTitleLabel.textColor = navigationTitleColor
+		navigationTitleLabel.font = Font.navigationTitleFont
+		navigationTitleLabel.textColor = ColorSet.navigationTitleColor
 	}
 	
 	func setupSubViews() {

--- a/DesignSystem/Sources/NavigationBar/NavigationBar.swift
+++ b/DesignSystem/Sources/NavigationBar/NavigationBar.swift
@@ -35,14 +35,14 @@ public class NavigationBar: UIView {
 	}
 	
 	// MARK: METRIC
-	private struct Metric {
-		let navigationBarHeight: CGFloat = 50
+	private enum Metric {
+		static let navigationBarHeight: CGFloat = 50
+
+		static let leftButtonSize: CGSize = .init(width: 30, height: 30)
+		static let leftButtonLeftMargin: CGFloat = 20
 		
-		let leftButtonSize: CGSize = .init(width: 30, height: 30)
-		let leftButtonLeftMargin: CGFloat = 20
-		
-		let navigationTitleTopMargin: CGFloat = 14
-		let navigationTitleBottomMargin: CGFloat = -15
+		static let navigationTitleTopMargin: CGFloat = 14
+		static let navigationTitleBottomMargin: CGFloat = -15
 	}
 	
 	// MARK: - OUTPUT
@@ -54,7 +54,6 @@ public class NavigationBar: UIView {
 	private let navigationLeftButtonColor: UIColor
 	private let navigationTitleFont: UIFont
 	private let navigationTitleColor: UIColor
-	private let metric: Metric
 	private let disposeBag: DisposeBag
 	
 	private let navigationLeftButton: UIButton = UIButton(type: .system)
@@ -70,7 +69,6 @@ public class NavigationBar: UIView {
 		self.navigationLeftButtonColor = .AppColor.appBlack
 		self.navigationTitleFont = .AppFont.Bold_18
 		self.navigationTitleColor = .AppColor.appBlack
-		self.metric = .init()
 		self.disposeBag = .init()
 		super.init(frame: .zero)
 		setupConfigure()
@@ -109,18 +107,18 @@ private extension NavigationBar {
 	
 	func setupConstraints() {
 		snp.makeConstraints { make in
-			make.height.equalTo(metric.navigationBarHeight)
+			make.height.equalTo(Metric.navigationBarHeight)
 		}
 		
 		navigationLeftButton.snp.makeConstraints { make in
-			make.leading.equalToSuperview().offset(metric.leftButtonLeftMargin)
+			make.leading.equalToSuperview().offset(Metric.leftButtonLeftMargin)
 			make.centerY.equalToSuperview()
-			make.size.equalTo(navigationType == .none ? 0 : metric.leftButtonSize)
+			make.size.equalTo(navigationType == .none ? 0 : Metric.leftButtonSize)
 		}
 		
 		navigationTitleLabel.snp.makeConstraints { make in
-			make.top.equalToSuperview().offset(metric.navigationTitleTopMargin)
-			make.bottom.equalToSuperview().offset(metric.navigationTitleBottomMargin)
+			make.top.equalToSuperview().offset(Metric.navigationTitleTopMargin)
+			make.bottom.equalToSuperview().offset(Metric.navigationTitleBottomMargin)
 			make.centerX.equalToSuperview()
 		}
 	}

--- a/DesignSystem/Sources/PhoneNumberInputView/CollectionView/PhoneNumberListCell.swift
+++ b/DesignSystem/Sources/PhoneNumberInputView/CollectionView/PhoneNumberListCell.swift
@@ -22,6 +22,11 @@ internal final class PhoneNumberListCell: UICollectionViewCell {
 		static let phoneNumberLabelHorzontalMargin: CGFloat = 28
 		static let phoneNumberLabelVerticalMargin: CGFloat = 18
 	}
+	
+	// MARK: ColorSet
+	private enum ColorSet {
+		static let backgroundColor: UIColor = .AppColor.appSecondary
+	}
   
   private let phoneNumberLabel: UILabel = UILabel().then {
     $0.font = .AppFont.Bold_20
@@ -53,7 +58,7 @@ internal final class PhoneNumberListCell: UICollectionViewCell {
 // MARK: - PRIVATE METHOD
 private extension PhoneNumberListCell {
   private func setupView() {
-    contentView.backgroundColor = .AppColor.appSecondary
+		contentView.backgroundColor = ColorSet.backgroundColor
   }
   
   private func setupLayout() {

--- a/DesignSystem/Sources/PhoneNumberInputView/CollectionView/PhoneNumberListCell.swift
+++ b/DesignSystem/Sources/PhoneNumberInputView/CollectionView/PhoneNumberListCell.swift
@@ -13,7 +13,15 @@ import SnapKit
 import Then
 
 internal final class PhoneNumberListCell: UICollectionViewCell {
+	
+	// MARK: IDENTIFIER
   static let idendifier: String = "PhoneNumberListCell"
+	
+	// MARK: METRIC
+	private enum Metric {
+		static let phoneNumberLabelHorzontalMargin: CGFloat = 28
+		static let phoneNumberLabelVerticalMargin: CGFloat = 18
+	}
   
   private let phoneNumberLabel: UILabel = UILabel().then {
     $0.font = .AppFont.Bold_20
@@ -56,8 +64,8 @@ private extension PhoneNumberListCell {
   
   private func setupConstraints() {
     phoneNumberLabel.snp.makeConstraints { make in
-      make.horizontalEdges.equalToSuperview().inset(28)
-      make.verticalEdges.equalToSuperview().inset(18)
+			make.horizontalEdges.equalToSuperview().inset(Metric.phoneNumberLabelHorzontalMargin)
+			make.verticalEdges.equalToSuperview().inset(Metric.phoneNumberLabelVerticalMargin)
     }
   }
 }

--- a/DesignSystem/Sources/PhoneNumberInputView/PhoneNumberInputView.swift
+++ b/DesignSystem/Sources/PhoneNumberInputView/PhoneNumberInputView.swift
@@ -24,13 +24,13 @@ public class PhoneNumberInputView: UIView {
   public var isPhoneNumberComplete: Observable<Bool>!
   
   // MARK: - METRIC
-  private struct Metric {
-    let firstNumberLabelLeftMargin: CGFloat = 16
-    let firstNumberLabelRightMargin: CGFloat = 8
-    let dropDownImageSize: CGSize = CGSize(width: 24, height: 24)
-    let dropDownImageRightMargin: CGFloat = -12
-    let textFieldHorizontalMargin: CGFloat = 28
-    let textFieldVerticalMargin: CGFloat = 18
+  private enum Metric {
+   static let firstNumberLabelLeftMargin: CGFloat = 16
+   static let firstNumberLabelRightMargin: CGFloat = 8
+   static let dropDownImageSize: CGSize = CGSize(width: 24, height: 24)
+   static let dropDownImageRightMargin: CGFloat = -12
+   static let textFieldHorizontalMargin: CGFloat = 28
+   static let textFieldVerticalMargin: CGFloat = 18
   }
   
   private let firstNumberBaseView: UIView = UIView().then {
@@ -102,7 +102,6 @@ public class PhoneNumberInputView: UIView {
     $0.distribution = .fillEqually
   }
   
-  private let metric: Metric
   private let viewModel: PhoneNumberInputViewModel
   private let disposeBag: DisposeBag
   
@@ -110,7 +109,6 @@ public class PhoneNumberInputView: UIView {
   
   /// firstNumber가 될 수 있는 배열을 생성자에서 받습니다.
   public init(with firstPhoneNumbers: [String]) {
-    self.metric = .init()
     self.disposeBag = .init()
     self.viewModel = PhoneNumberInputViewModelImpl()
     super.init(frame: .zero)
@@ -170,17 +168,17 @@ private extension PhoneNumberInputView {
     
     firstNumberLabel.snp.makeConstraints { make in
       make.leading.equalToSuperview()
-				.offset(metric.firstNumberLabelLeftMargin)
+				.offset(Metric.firstNumberLabelLeftMargin)
       make.trailing.equalTo(dropDownImageView.snp.leading)
-				.offset(metric.firstNumberLabelRightMargin)
+				.offset(Metric.firstNumberLabelRightMargin)
       make.verticalEdges.equalToSuperview()
-				.inset(metric.textFieldVerticalMargin)
+				.inset(Metric.textFieldVerticalMargin)
     }
     
     dropDownImageView.snp.makeConstraints { make in
       make.centerY.equalToSuperview()
-      make.trailing.equalToSuperview().offset(metric.dropDownImageRightMargin)
-      make.size.equalTo(metric.dropDownImageSize)
+      make.trailing.equalToSuperview().offset(Metric.dropDownImageRightMargin)
+      make.size.equalTo(Metric.dropDownImageSize)
     }
     
     dropDownExtendableCollectionView.snp.makeConstraints { make in
@@ -190,13 +188,13 @@ private extension PhoneNumberInputView {
     }
     
     middleNumberTextField.snp.makeConstraints { make in
-      make.horizontalEdges.equalToSuperview().inset(metric.textFieldHorizontalMargin)
-      make.verticalEdges.equalToSuperview().inset(metric.textFieldVerticalMargin)
+      make.horizontalEdges.equalToSuperview().inset(Metric.textFieldHorizontalMargin)
+      make.verticalEdges.equalToSuperview().inset(Metric.textFieldVerticalMargin)
     }
     
     lastNumberTextField.snp.makeConstraints { make in
-      make.horizontalEdges.equalToSuperview().inset(metric.textFieldHorizontalMargin)
-      make.verticalEdges.equalToSuperview().inset(metric.textFieldVerticalMargin)
+      make.horizontalEdges.equalToSuperview().inset(Metric.textFieldHorizontalMargin)
+      make.verticalEdges.equalToSuperview().inset(Metric.textFieldVerticalMargin)
     }
     
     phoneNumberInputStackView.snp.makeConstraints { make in

--- a/DesignSystem/Sources/TextFields/DefaultTextField.swift
+++ b/DesignSystem/Sources/TextFields/DefaultTextField.swift
@@ -64,23 +64,23 @@ public class DefaultTextField: UIView {
   
   // MARK: METRIC
   /// DefaultTextField의 크기 요소를 정의합니다.
-  private struct Metric {
-    let textFieldLeftMargin = 16
-    let textFieldRightMargin = -8
-    let textFieldTopMargin = 14
-    let textFieldBottomMargin = -15
+  private enum Metric {
+    static let textFieldLeftMargin = 16
+    static let textFieldRightMargin = -8
+    static let textFieldTopMargin = 14
+    static let textFieldBottomMargin = -15
     
-    let clearButtonSize = 16
-    let clearButtonRightMargin = -16
+    static let clearButtonSize = 16
+    static let clearButtonRightMargin = -16
     
-    let securityButtonSize = 16
-    let securitRightMargin = -8
+    static let securityButtonSize = 16
+    static let securitRightMargin = -8
     
-    let textButtonVerticalMargin = 17
-    let textButtonRightMargin = -16
+    static let textButtonVerticalMargin = 17
+    static let textButtonRightMargin = -16
     
-    let height = 46
-    let cornerRadius = 16.0
+    static let height = 46
+    static let cornerRadius = 16.0
   }
   
   // MARK: INPUT PROPERTY
@@ -91,7 +91,6 @@ public class DefaultTextField: UIView {
   private let baseBackgroundColor: UIColor
   private let textFieldFont: UIFont
   private let textFieldColor: UIColor
-  private let metric: Metric
   private let disposeBag: DisposeBag
   
   // MARK: UI PROPERTY
@@ -122,7 +121,6 @@ public class DefaultTextField: UIView {
     self.baseBackgroundColor = .AppColor.appGrey90
     self.textFieldFont = .AppFont.Regular_12
     self.textFieldColor = .AppColor.appBlack
-    self.metric = .init()
     self.disposeBag = .init()
     super.init(frame: .zero)
     self.setupSubViews()
@@ -164,56 +162,56 @@ private extension DefaultTextField {
   /// DefaultTextField의 SubView의 오토레이아웃을 정의합니다.
   func setupConstrains() {
     snp.makeConstraints { make in
-      make.height.equalTo(metric.height)
+      make.height.equalTo(Metric.height)
     }
     
     switch type {
     case .email, .name:
       clearButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(metric.clearButtonRightMargin)
+        make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
         make.centerY.equalToSuperview()
-        make.size.equalTo(metric.clearButtonSize)
+        make.size.equalTo(Metric.clearButtonSize)
       }
       
       textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(metric.textFieldLeftMargin)
-        make.trailing.equalTo(clearButton.snp.leading).offset(metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(metric.textFieldBottomMargin)
+        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+        make.trailing.equalTo(clearButton.snp.leading).offset(Metric.textFieldRightMargin)
+        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
       }
 
     case .password:
       clearButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(metric.clearButtonRightMargin)
+        make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
         make.centerY.equalToSuperview()
-        make.size.equalTo(metric.clearButtonSize)
+        make.size.equalTo(Metric.clearButtonSize)
       }
       
       securityButton.snp.makeConstraints { make in
-        make.trailing.equalTo(clearButton.snp.leading).offset(metric.securitRightMargin)
+        make.trailing.equalTo(clearButton.snp.leading).offset(Metric.securitRightMargin)
         make.centerY.equalToSuperview()
-        make.size.equalTo(metric.securityButtonSize)
+        make.size.equalTo(Metric.securityButtonSize)
       }
       
       textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(metric.textFieldLeftMargin)
-        make.trailing.equalTo(securityButton.snp.leading).offset(metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(metric.textFieldBottomMargin)
+        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+        make.trailing.equalTo(securityButton.snp.leading).offset(Metric.textFieldRightMargin)
+        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
       }
 
     case .emailAuthCode:
       textButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(metric.textButtonRightMargin)
-        make.verticalEdges.equalToSuperview().inset(metric.textButtonVerticalMargin)
+        make.trailing.equalToSuperview().offset(Metric.textButtonRightMargin)
+        make.verticalEdges.equalToSuperview().inset(Metric.textButtonVerticalMargin)
         make.width.equalTo(textButton.intrinsicContentSize.width)
       }
       
       textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(metric.textFieldLeftMargin)
-        make.trailing.equalTo(textButton.snp.leading).offset(metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(metric.textFieldBottomMargin)
+        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+        make.trailing.equalTo(textButton.snp.leading).offset(Metric.textFieldRightMargin)
+        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
       }
     }
   }

--- a/DesignSystem/Sources/TextFields/DefaultTextField.swift
+++ b/DesignSystem/Sources/TextFields/DefaultTextField.swift
@@ -82,15 +82,22 @@ public class DefaultTextField: UIView {
     static let height = 46
     static let cornerRadius = 16.0
   }
+	
+	// MARK: Font
+	private enum Font {
+		static let textFieldFont: UIFont = .AppFont.Regular_12
+	}
+	
+	private enum ColorSet {
+		static let baseBackgroundColor: UIColor = .AppColor.appGrey90
+		static let textFieldColor: UIColor = .AppColor.appBlack
+	}
   
   // MARK: INPUT PROPERTY
   private let type: DefaultTextFieldType
   private let keyboardType: UIKeyboardType
   
   // MARK: PROPERTY
-  private let baseBackgroundColor: UIColor
-  private let textFieldFont: UIFont
-  private let textFieldColor: UIColor
   private let disposeBag: DisposeBag
   
   // MARK: UI PROPERTY
@@ -118,9 +125,6 @@ public class DefaultTextField: UIView {
   ) {
     self.type = type
     self.keyboardType = keyboardType
-    self.baseBackgroundColor = .AppColor.appGrey90
-    self.textFieldFont = .AppFont.Regular_12
-    self.textFieldColor = .AppColor.appBlack
     self.disposeBag = .init()
     super.init(frame: .zero)
     self.setupSubViews()
@@ -219,13 +223,13 @@ private extension DefaultTextField {
   /// DefaultTextField의 타입에 따른 이미지를 정의합니다.
   func setupConfiguration() {
     makeCornerRadius(16)
-    backgroundColor = baseBackgroundColor
+		backgroundColor = ColorSet.baseBackgroundColor
     
     textField.keyboardType = keyboardType
     textField.placeholder = type.placeHolder
-    textField.textColor = textFieldColor
-    textField.tintColor = textFieldColor
-    textField.font = textFieldFont
+		textField.textColor = ColorSet.textFieldColor
+		textField.tintColor = ColorSet.textFieldColor
+		textField.font = Font.textFieldFont
     textField.isSecureTextEntry = type.security
   }
   

--- a/DesignSystem/Sources/TextFields/IconBorderTextField.swift
+++ b/DesignSystem/Sources/TextFields/IconBorderTextField.swift
@@ -67,14 +67,22 @@ public class IconBorderTextField: UIView {
    static let cornerRadius = 16.0
    static let iconSize = 18
   }
+	
+	// MARK: Font
+	private enum Font {
+		static let textFieldFont: UIFont = .AppFont.Regular_12
+	}
+	
+	// MARK: ColorSet
+	private enum ColorSet {
+		static let textFieldColor: UIColor = .AppColor.appBlack
+	}
   
   // MARK: INPUT PROPERTY
   private let type: IconBorderTextFieldType
   private let keyboardType: UIKeyboardType
   
   // MARK: PROPERTY
-  private let textFieldFont: UIFont
-  private let textFieldColor: UIColor
   private let disposeBag: DisposeBag
   
   // MARK: UI PROPERTY
@@ -88,8 +96,6 @@ public class IconBorderTextField: UIView {
   ) {
     self.type = type
     self.keyboardType = keyboardType
-    self.textFieldFont = .AppFont.Regular_12
-    self.textFieldColor = .AppColor.appBlack
     self.disposeBag = .init()
     super.init(frame: .zero)
     self.setupSubViews()
@@ -147,9 +153,9 @@ private extension IconBorderTextField {
     
     textField.keyboardType = keyboardType
     textField.placeholder = type.placeHolder
-    textField.textColor = textFieldColor
-    textField.tintColor = textFieldColor
-    textField.font = textFieldFont
+		textField.textColor = ColorSet.textFieldColor
+		textField.tintColor = ColorSet.textFieldColor
+		textField.font = Font.textFieldFont
     textField.isSecureTextEntry = type.security
   }
   

--- a/DesignSystem/Sources/TextFields/IconBorderTextField.swift
+++ b/DesignSystem/Sources/TextFields/IconBorderTextField.swift
@@ -55,17 +55,17 @@ public class IconBorderTextField: UIView {
   
   // MARK: METRIC
   /// IconBorderTextField의 크기 요소를 정의합니다.
-  private struct Metric {
-    let iconImageLeftMargin = 16
-    let iconImageTopMargin = 13
-    let iconImageBottomMargin = -15
-    
-    let textFieldLeftMargin = 8
-    let textFieldRightMargin = -16
-    
-    let height = 46
-    let cornerRadius = 16.0
-    let iconSize = 18
+  private enum Metric {
+   static let iconImageLeftMargin = 16
+   static let iconImageTopMargin = 13
+   static let iconImageBottomMargin = -15
+   
+   static let textFieldLeftMargin = 8
+   static let textFieldRightMargin = -16
+   
+   static let height = 46
+   static let cornerRadius = 16.0
+   static let iconSize = 18
   }
   
   // MARK: INPUT PROPERTY
@@ -75,7 +75,6 @@ public class IconBorderTextField: UIView {
   // MARK: PROPERTY
   private let textFieldFont: UIFont
   private let textFieldColor: UIColor
-  private let metric: Metric
   private let disposeBag: DisposeBag
   
   // MARK: UI PROPERTY
@@ -91,7 +90,6 @@ public class IconBorderTextField: UIView {
     self.keyboardType = keyboardType
     self.textFieldFont = .AppFont.Regular_12
     self.textFieldColor = .AppColor.appBlack
-    self.metric = .init()
     self.disposeBag = .init()
     super.init(frame: .zero)
     self.setupSubViews()
@@ -124,26 +122,26 @@ private extension IconBorderTextField {
   /// IconBorderTextField의 SubView의 오토레이아웃을 정의합니다.
   func setupConstrains() {
     snp.makeConstraints { make in
-      make.height.equalTo(metric.height)
+      make.height.equalTo(Metric.height)
     }
     
     iconImageView.snp.makeConstraints { make in
-      make.leading.equalToSuperview().offset(metric.iconImageLeftMargin)
-      make.top.equalToSuperview().offset(metric.iconImageTopMargin)
-      make.bottom.equalToSuperview().offset(metric.iconImageBottomMargin)
-      make.size.equalTo(metric.iconSize)
+      make.leading.equalToSuperview().offset(Metric.iconImageLeftMargin)
+      make.top.equalToSuperview().offset(Metric.iconImageTopMargin)
+      make.bottom.equalToSuperview().offset(Metric.iconImageBottomMargin)
+      make.size.equalTo(Metric.iconSize)
     }
     
     textField.snp.makeConstraints { make in
-      make.leading.equalTo(iconImageView.snp.trailing).offset(metric.textFieldLeftMargin)
-      make.trailing.equalToSuperview().offset(metric.textFieldRightMargin)
+      make.leading.equalTo(iconImageView.snp.trailing).offset(Metric.textFieldLeftMargin)
+      make.trailing.equalToSuperview().offset(Metric.textFieldRightMargin)
       make.centerY.equalTo(iconImageView.snp.centerY)
     }
   }
   
   /// IconBorderTextField의 타입에 따른 이미지를 정의합니다.
   func setupConfiguration() {
-    makeCornerRadiusWithBorder(metric.cornerRadius)
+    makeCornerRadiusWithBorder(Metric.cornerRadius)
     
     iconImageView.image = type.iconImage
     


### PR DESCRIPTION
### 배경
기존 유지 보수의 이점을 가져오기 위해, layout등의 상수에 있어 `struct` 타입으로 지정
struct로 생성 시, 생성자가 제공되지 않는 자요형을 사용하지 못함. **(동겸(@Donggaem ) 의견)**

### 변경사항
1. Metric, ColorSet 등 struct에서 enum으로 변경
2. static을 통해 타입 프로퍼티로 접근 가능하도록 설정
3. 적용되지 않았던 상수 값 모두 enum으로 관리