### PR TITLE
`DesignSystem` `makeAttributedStringWithFont` 함수 추가

### DIFF
--- a/DesignSystem/Sources/Extensions/AttributedString+Extension.swift
+++ b/DesignSystem/Sources/Extensions/AttributedString+Extension.swift
@@ -1,0 +1,32 @@
+//
+//  AttributedString+Extension.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/07.
+//
+
+import UIKit
+
+import ResourceKit
+
+public extension AttributedString {
+	
+	/// AttributedString을 반환하는 함수입니다.
+	/// 원하는 텍스트와, 폰트를 적용할 수 있습니다.
+	static func makeAttributedStringWithFont(
+		text: String,
+		font: UIFont = .AppFont.Regular_12
+	) -> AttributedString {
+		
+		let attributes: [NSAttributedString.Key: Any] = [
+			.font: font
+		]
+		
+		let attributedString = NSAttributedString(
+			string: text,
+			attributes: attributes
+		)
+		
+		return AttributedString(attributedString)
+	}
+}


### PR DESCRIPTION
### 배경
특정 경우에, AttributedString 타입을 적용해야 하는 경우가 생김.
이때 내부에서 많은 코드(중복 코드)가 생겨 이를 방지하고자 함

### 적용사항
1. 사용자로부터 텍스트와 폰트를 주입 받음
2. 폰트가 적용된 텍스트를 NSAttributedString 타입으로 만듬
3. AttributedString로 감싸 반환

### 적용 예시
``` swift
private let attributedString = AttributedString.makeAttributedStringWithFont(
  text: "ATTRIBUTEDSTRING",
  font: UIFont
)
```
