### PR TITLE
`DesignSystem` 이미지 사이즈 변경을 위한 `changeImageSize`

### DIFF
--- a/DesignSystem/Sources/Extensions/UIImage+Extension.swift
+++ b/DesignSystem/Sources/Extensions/UIImage+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  UIImage+Extension.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/07.
+//
+
+import UIKit
+
+public extension UIImage {
+	/// 이미지 적용 시, 크기를 변경해 적요합니다.
+	/// 버튼에 이미지를 추가하는 경우 사용됩니다.
+	func changeImageSize(size: CGSize) -> UIImage? {
+		let frame = CGRect(origin: CGPoint.zero, size: size)
+		UIGraphicsBeginImageContextWithOptions(frame.size, false, 0)
+		self.draw(in: frame)
+		let resizedImage: UIImage? = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		self.withRenderingMode(.alwaysOriginal)
+		return resizedImage
+	}
+}


### PR DESCRIPTION
### 배경
버튼에 이미지 적용 시, 사이즈가 맞지 않는 오류가 발생
디자인에 맞춰 사이즈를 적용할 수 있는 함수가 필요

### 변경사항
1. UIImage extension내, 이미지 사이즈 변경 함수 추가
2. 해당 함수는 옵셔널 이미지 타입을 반환

### 적용 예시
``` swift
private let newImage: UIImage? = image.changeImageSize(size: .init(width: 16, height: 16))
```