### PR TITLE
`DesignSystem` 상단 경고 창 등에 활용되는 `HeaderSlideView` 추가

### DIFF
--- a/DesignSystem/Sources/Extensions/UIDevice+Extension.swift
+++ b/DesignSystem/Sources/Extensions/UIDevice+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  UIDevice+Extension.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/07.
+//
+
+import UIKit
+
+extension UIDevice {
+	public static var hasNotch: Bool {
+		if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+			if let window = windowScene.windows.first {
+				return window.safeAreaInsets.bottom > 0
+			}
+		}
+		return false
+	}
+}

--- a/DesignSystem/Sources/HeaderSlideView/HeaderSlideView.swift
+++ b/DesignSystem/Sources/HeaderSlideView/HeaderSlideView.swift
@@ -1,0 +1,182 @@
+//
+//  HeaderSlideView.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/07.
+//
+
+import UIKit
+
+import ResourceKit
+
+import SnapKit
+import Then
+
+public class HeaderSlideView: UIView {
+	
+	// MARK: - HeaderSlideViewType
+	public enum HeaderSlideViewType {
+		case loginError
+		
+		var text: String {
+			switch self {
+			case .loginError:
+				return "로그인에 실패하였습니다.\n비밀번호를 확인해주세요."
+			}
+		}
+		
+		var backgroundColor: UIColor {
+			switch self {
+			case .loginError:
+				return .AppColor.appWarning
+			}
+		}
+		
+		var textColor: UIColor {
+			switch self {
+			case .loginError:
+				return .AppColor.appWhite
+			}
+		}
+		
+		var font: UIFont {
+			switch self {
+			case .loginError:
+				return .AppFont.Regular_14
+			}
+		}
+	}
+	
+	// MARK: - PUBLIC PROPERTY
+	public var isActive: Bool {
+		return parentVC != nil
+	}
+	
+	// MARK: - PROPERTY
+	private let type: HeaderSlideViewType
+	private let duration: TimeInterval
+	private let visibleTime: TimeInterval
+	private var parentVC: UIViewController?
+	
+	// MARK: - UI PROPERTY
+	private let titleLabel: UILabel = UILabel().then {
+		$0.textAlignment = .center
+	}
+	
+	public init(
+		_ type: HeaderSlideViewType,
+		duration: TimeInterval = 0.3,
+		visibleTime: TimeInterval = 2.0
+	) {
+		self.type = type
+		self.duration = duration
+		self.visibleTime = visibleTime
+		super.init(frame: .zero)
+		setupViewConfigure()
+		setupSubViews()
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	// MARK: - PUBLIC METHOD
+	
+	/// 애니메이션을 시작하는 함수입니다.
+	/// 실제 VC에서 사용하게 될 경우, .startAnimation(at: self)로 사용하면 됩니다.
+	/// 해당 slideView는 별도 hide액션이 없으며, 시간 경과 후 자동으로 사라집니다
+	/// 시간은 기본값이 지정되어 있지만 필요에 따라 주입해주면 됩니다.
+	public func startAnimation(at parentVC: UIViewController) {
+		if isActive == false {
+			self.parentVC = parentVC
+			setupInitialConfigure()
+			setupInitialLayoutAtSuperView(at: parentVC)
+			animateToShowDown()
+		}
+	}
+}
+
+// MARK: - PRIVATE METHOD
+private extension HeaderSlideView {
+	
+	func setupViewConfigure() {
+		backgroundColor = type.backgroundColor
+		
+		titleLabel.text = type.text
+		titleLabel.textColor = type.textColor
+		titleLabel.font = type.font
+	}
+	
+	func setupSubViews() {
+		addSubview(titleLabel)
+		
+		setupConstraints()
+	}
+	
+	enum Metric {
+		static let titleLabelTopMargin: CGFloat = UIDevice.hasNotch ? 52 : 24
+		static let titleLabelBottomMargin: CGFloat = -12
+	}
+	
+	func setupConstraints() {
+		titleLabel.snp.makeConstraints { make in
+			make.top.equalToSuperview().offset(Metric.titleLabelTopMargin)
+			make.bottom.equalToSuperview().offset(Metric.titleLabelBottomMargin)
+			make.horizontalEdges.equalToSuperview()
+		}
+	}
+	
+	func setupInitialConfigure() {
+		self.alpha = 0.0
+	}
+	
+	func setupInitialLayoutAtSuperView(at parentVC: UIViewController) {
+		parentVC.view.addSubview(self)
+		
+		self.snp.makeConstraints { make in
+			make.horizontalEdges.equalToSuperview()
+			make.bottom.equalTo(parentVC.view.snp.top)
+		}
+		
+		parentVC.view.layoutIfNeeded()
+	}
+	
+	func animateToShowDown() {
+		guard let parentVC else { return }
+		let shownHeight: CGFloat = self.frame.height
+		UIView.animate(
+			withDuration: duration,
+			delay: 0.0,
+			options: .curveEaseOut,
+			animations: {
+				self.alpha = 1.0
+				self.snp.updateConstraints { make in
+					make.bottom.equalTo(parentVC.view.snp.top).offset(shownHeight)
+				}
+				parentVC.view.layoutIfNeeded()
+			}, completion: { _ in
+				self.animateToHideUp()
+			}
+		)
+	}
+	
+	func animateToHideUp() {
+		guard let parentVC else { return }
+		UIView.animate(
+			withDuration: duration,
+			delay: visibleTime,
+			options: .curveEaseOut,
+			animations: {
+				self.alpha = 0.0
+				self.snp.updateConstraints { make in
+					make.bottom.equalTo(parentVC.view.snp.top)
+				}
+				parentVC.view.layoutIfNeeded()
+			}, completion: { _ in
+				self.removeFromSuperview()
+				self.snp.removeConstraints()
+				self.parentVC = nil
+			}
+		)
+	}
+}


### PR DESCRIPTION
### 배경
로그인 등이 실패하게 되면, 토스트와 비슷한 상단 경고창이 필요

### 적용사항
1. UIDevice.hasNotch
> * 기기 별 노치 여부에 따라 bottom 또는 top margin을 다르게 줘야 되는 경우가 생겨 추가
> * Bool 값을 통해 상황에 맞춰 사용하면 됌

2. HeaderSlideView
> * type을 내부에서 지정해, 배경색 및 문구를 외부에서 별도 지정할 필요는 없음
> * 외부에서는 별도의 레이아웃을 선언할 필요 없이, 버튼 액션 등에 `.startAnimation(at: UIViewController)` 함수를 호출하면 됌
> * 내부에서는 보여지는 ViewController에 'HeaderSlideView'가 없을 때만 동작하도록 설계되었기에, 중첩 생성 되지는 않음.
> `isActive` 외부에서 현재 slideView가 활성화 상태인지를 확인하기 위한 값으로, public 접근자 입니다.

### 적용 예시

#### 1. UIDevice.hasNotch

``` swift 
private func checkingHasNotch() {
  print(UIDevice.hasNotch)
  // 노치 있는 경우: true
  // 노치 없는 경우: false
}
```

#### 2. HeaderSlideView

``` swift
import DesignSystem

final class ViewController: UIViewController {
  private let headerSlideView = HeaderSlideView(.loginError) // 🚨주의사항: 별도의 레이아웃을 잡아 줄 필요 없습니다. 

  // 코드 생략

  private func ifLoginFailed() {
    headerSlideView.startAnimation(at: self)
  }
}
```

### 결과
노치 X | 노치 O
--- | ---
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/f5641096-73cf-4483-a1a8-2789565ccf31"> | <img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/b2a7fbb2-1f73-466a-afa9-5202c6754148">