### PR TITLE
`DesignSystem` PageController 사용성 확대 

### DIFF
--- a/DesignSystem/Sources/ProgressBar/PageController.swift
+++ b/DesignSystem/Sources/ProgressBar/PageController.swift
@@ -81,6 +81,28 @@ public class PageController: UIView {
       }
     )
   }
+	
+	/// 외부에서 이전 페이지로 넘어가기 위해 사용됩니다.
+	public func moveToPrevPage() {
+		UIView.animate(
+			withDuration: durationTime,
+			animations: {
+				if self.currentPage > 0 {
+					self.currentPage -= 1
+					self.progressBar.snp.remakeConstraints { make in
+						make.leading.equalTo(self.pageControllerCollection[self.currentPage].snp.leading)
+						make.centerY.equalTo(self.pageControllerStackView.snp.centerY)
+						make.size.equalTo(self.selectedControllerSize)
+					}
+					
+					self.pageControllerCollection[self.currentPage+1].backgroundColor = self.defaultColor
+					self.pageControllerCollection[self.currentPage].backgroundColor = .clear
+
+					self.layoutIfNeeded()
+				}
+			}
+		)
+	}
   
   /// 외부에서 첫 페이지로 넘어가기 위해 사용됩니다.
   public func moveToFirstPage() {

--- a/DesignSystem/Sources/ProgressBar/PageController.swift
+++ b/DesignSystem/Sources/ProgressBar/PageController.swift
@@ -128,6 +128,11 @@ public class PageController: UIView {
 	public func initCurrentPage() {
 		currentPage = 0
 	}
+	
+	/// 외부에서 현재 페이지를 조회할 때 사용되는 함수입니다.
+	public func getCurrentPage() -> Int {
+		return currentPage
+	}
 }
 
 // MARK: - PRIVATE METHOD

--- a/DesignSystem/Sources/ProgressBar/PageController.swift
+++ b/DesignSystem/Sources/ProgressBar/PageController.swift
@@ -24,7 +24,7 @@ public class PageController: UIView {
   private let selectedControllerSize: CGSize
   private let durationTime: TimeInterval
   
-  private var currentIndex: Int = 0
+  private var currentPage: Int = 0
   private var pageControllerCollection: [UIView] = []
   
   private let pageControllerStackView: UIStackView = UIStackView()
@@ -65,16 +65,16 @@ public class PageController: UIView {
     UIView.animate(
       withDuration: durationTime,
       animations: {
-        if self.currentIndex < self.pageCount - 1 {
-          self.currentIndex += 1
+        if self.currentPage < self.pageCount - 1 {
+          self.currentPage += 1
           self.progressBar.snp.remakeConstraints { make in
-            make.leading.equalTo(self.pageControllerCollection[self.currentIndex].snp.leading)
+            make.leading.equalTo(self.pageControllerCollection[self.currentPage].snp.leading)
             make.centerY.equalTo(self.pageControllerStackView.snp.centerY)
             make.size.equalTo(self.selectedControllerSize)
           }
           
-          self.pageControllerCollection[self.currentIndex-1].backgroundColor = self.defaultColor
-          self.pageControllerCollection[self.currentIndex].backgroundColor = .clear
+          self.pageControllerCollection[self.currentPage-1].backgroundColor = self.defaultColor
+          self.pageControllerCollection[self.currentPage].backgroundColor = .clear
 
           self.layoutIfNeeded()
         }
@@ -87,9 +87,9 @@ public class PageController: UIView {
     UIView.animate(
       withDuration: durationTime,
       animations: {
-        self.currentIndex = 0
+        self.currentPage = 0
         self.progressBar.snp.remakeConstraints { make in
-          make.leading.equalTo(self.pageControllerCollection[self.currentIndex].snp.leading)
+          make.leading.equalTo(self.pageControllerCollection[self.currentPage].snp.leading)
           make.centerY.equalTo(self.pageControllerStackView.snp.centerY)
           make.size.equalTo(self.selectedControllerSize)
         }
@@ -141,7 +141,7 @@ private extension PageController {
     }
     
     progressBar.snp.makeConstraints { make in
-      make.leading.equalTo(pageControllerCollection[currentIndex].snp.leading)
+      make.leading.equalTo(pageControllerCollection[currentPage].snp.leading)
       make.centerY.equalTo(pageControllerStackView.snp.centerY)
       make.size.equalTo(selectedControllerSize)
     }

--- a/DesignSystem/Sources/ProgressBar/PageController.swift
+++ b/DesignSystem/Sources/ProgressBar/PageController.swift
@@ -109,7 +109,7 @@ public class PageController: UIView {
     UIView.animate(
       withDuration: durationTime,
       animations: {
-        self.currentPage = 0
+        self.initCurrentPage()
         self.progressBar.snp.remakeConstraints { make in
           make.leading.equalTo(self.pageControllerCollection[self.currentPage].snp.leading)
           make.centerY.equalTo(self.pageControllerStackView.snp.centerY)
@@ -121,6 +121,13 @@ public class PageController: UIView {
     
     pageControllerCollection.forEach { $0.backgroundColor = defaultColor }
   }
+	
+	/// 외부에서 현재 페이지를 0으로 초기화 할 때 사용합니다.
+	/// moveToFirstPage와는 다르게, UI 변경사항이 없습니다.
+	/// 따라서 moveToFirstPage와 함께 사용할 필요는 없습니다.
+	public func initCurrentPage() {
+		currentPage = 0
+	}
 }
 
 // MARK: - PRIVATE METHOD


### PR DESCRIPTION
### 배경
PageController의 확장성이 필요했음
1. 첫 페이지가 아닌 이전 페이지로 돌아가는 액션 필요
2. 현재 페이지 조회 필요
3. 페이지 초기화 필요

### 변경사항
1. 변수명 변경
> * 내부에서 사용되던 currentIndex 변수를 currentPage로 이름을 변경했습니다
> * 외부에서 변경되는 점은 없습니다.

2. moveToPrevPage() 추가
> * 이전 페이지로 돌아가게 될 경우 사용됩니다.
> * `currentPage > 0` 인 경우에 동작하기 때문에 첫 페이지에서는 동작하지 않습니다.

3. initCurrentPage()
> * 현재 페이지를 0으로 만듭니다.
> * 애니메이션과 함께 동작하지 않으며, 단순히 페이지를 0으로 만듭니다.
> * 따라서 moveToFirstPage() 메소드와 함께 사용할 일은 없습니다.

4. getCurrentPage()
> * 현재 페이지를 외부에서 조회할 경우 사용됩니다.
> * Int 타입을 반환합ㄴ디ㅏ.

### 결과

<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/2fd6ac34-c8eb-4d7e-ac68-b89892a1681b">