### PR TITLE
`DesignSystem` DefaultTextField `currentState` 적용

### DIFF
--- a/DesignSystem/Sources/TextFields/DefaultTextField.swift
+++ b/DesignSystem/Sources/TextFields/DefaultTextField.swift
@@ -21,6 +21,25 @@ public class DefaultTextField: UIView {
   
   // MARK: ACTION CLOSURE
   public var didTapTextButton: (() -> Void)?
+	public var currentState: DefaultTextFieldState = .normal {
+		didSet {
+			switch currentState {
+			case .normal:
+				makeBorder(borderColor: .clear)
+			case .success:
+				makeBorder(borderColor: .AppColor.appPrimary)
+			case .failure:
+				makeBorder(borderColor: .AppColor.appWarning)
+			}
+		}
+	}
+	
+	// MARK: State
+	public enum DefaultTextFieldState {
+		case normal
+		case success
+		case failure
+	}
   
   // MARK: TYPE
   /// DefaultTextField에 적용할 타입입니다.
@@ -225,6 +244,8 @@ private extension DefaultTextField {
     makeCornerRadius(16)
 		backgroundColor = ColorSet.baseBackgroundColor
     
+		makeBorder(borderColor: .AppColor.appWarning)
+		
     textField.keyboardType = keyboardType
     textField.placeholder = type.placeHolder
 		textField.textColor = ColorSet.textFieldColor


### PR DESCRIPTION
### 배경
상태에 따라 텍스트필드 `borderColor`를 변경해줘야 하는 이슈

### 변경사항
1. DefaultTextFiledType 적용
2. currentState public 변수 선언

### 적용 방법
``` swift
final class ViewController: UIViewController {
  private let textField: DefaultTextField = DetaultTextField()

  // 코드 생략

  private func setNormalStyle() {
    textField.currentState = .normal
  }
  
  private func setSuccessStyle() {
    textField.currentState = .success
  }

  private func setFailureStyle() {
    textField.currentState = .failure
  }
}
```

### 결과

.normal | .success | .failure
--- | --- | ---
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/fcd47409-e5bc-482e-9ebe-3540445d27f5"> | <img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/896f250d-1bc9-4a7b-bbb9-3e0c29991b81"> | <img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/8adb60bf-924f-4eb5-be52-f0534dc08b4a">