### PR TITLE
`DesignSystem` DefaultTextField `CustomType` 추가

### DIFF
--- a/DesignSystem/Sources/TextFields/DefaultTextField.swift
+++ b/DesignSystem/Sources/TextFields/DefaultTextField.swift
@@ -15,12 +15,12 @@ import SnapKit
 import Then
 
 public class DefaultTextField: UIView {
-  
-  // MARK: OUTPUT PROPERTY
-  public let currentText: BehaviorRelay<String> = BehaviorRelay<String>(value: "")
-  
-  // MARK: ACTION CLOSURE
-  public var didTapTextButton: (() -> Void)?
+	
+	// MARK: OUTPUT PROPERTY
+	public let currentText: BehaviorRelay<String> = BehaviorRelay<String>(value: "")
+	
+	// MARK: ACTION CLOSURE
+	public var didTapTextButton: (() -> Void)?
 	public var currentState: DefaultTextFieldState = .normal {
 		didSet {
 			switch currentState {
@@ -40,67 +40,58 @@ public class DefaultTextField: UIView {
 		case success
 		case failure
 	}
-  
-  // MARK: TYPE
-  /// DefaultTextField에 적용할 타입입니다.
-  public enum DefaultTextFieldType {
-    case email
-    case password
-    case emailAuthCode
-    case name
-    
-    fileprivate var placeHolder: String {
-      switch self {
-      case .email:
-        return "이메일"
-      case .password:
-        return "비밀번호"
-      case .emailAuthCode:
-        return "인증번호"
-      case .name:
-        return "김동겸"
-      }
-    }
-    
-    fileprivate var security: Bool {
-      switch self {
-      case .email, .emailAuthCode, .name:
-        return false
-      case .password:
-        return true
-      }
-    }
-    
-    fileprivate var buttonTitle: String {
-      switch self {
-      case .emailAuthCode:
-        return "인증번호 재전송"
-      default:
-        return ""
-      }
-    }
-  }
-  
-  // MARK: METRIC
-  /// DefaultTextField의 크기 요소를 정의합니다.
-  private enum Metric {
-    static let textFieldLeftMargin = 16
-    static let textFieldRightMargin = -8
-    static let textFieldTopMargin = 14
-    static let textFieldBottomMargin = -15
-    
-    static let clearButtonSize = 16
-    static let clearButtonRightMargin = -16
-    
-    static let securityButtonSize = 16
-    static let securitRightMargin = -8
-    
-    static let textButtonVerticalMargin = 17
-    static let textButtonRightMargin = -16
-    
-    static let height = 46
-    static let cornerRadius = 16.0
-  }
+	
+	// MARK: TYPE
+	/// DefaultTextField에 적용할 타입입니다.
+	public enum DefaultTextFieldType {
+		case email
+		case password
+		case name
+		case custom
+		
+		fileprivate var placeHolder: String {
+			switch self {
+			case .email:
+				return "이메일"
+			case .password:
+				return "비밀번호"
+			case .name:
+				return "김동겸"
+			case .custom:
+				return ""
+			}
+		}
+		
+		fileprivate var security: Bool {
+			switch self {
+			case .email, .name, .custom:
+				return false
+			case .password:
+				return true
+			}
+		}
+	}
+	
+	// MARK: METRIC
+	/// DefaultTextField의 크기 요소를 정의합니다.
+	private enum Metric {
+		static let textFieldLeftMargin = 16
+		static let textFieldRightMargin = -8
+		static let textFieldTopMargin = 14
+		static let textFieldBottomMargin = -15
+		
+		static let clearButtonSize = 16
+		static let clearButtonRightMargin = -16
+		
+		static let securityButtonSize = 16
+		static let securitRightMargin = -8
+		
+		static let customViewVerticalMargin = 17
+		static let customViewRightMargin = -16
+		
+		static let height = 46
+		static let cornerRadius = 16.0
+	}
 	
 	// MARK: Font
 	private enum Font {
@@ -111,179 +102,180 @@ public class DefaultTextField: UIView {
 		static let baseBackgroundColor: UIColor = .AppColor.appGrey90
 		static let textFieldColor: UIColor = .AppColor.appBlack
 	}
-  
-  // MARK: INPUT PROPERTY
-  private let type: DefaultTextFieldType
-  private let keyboardType: UIKeyboardType
-  
-  // MARK: PROPERTY
-  private let disposeBag: DisposeBag
-  
-  // MARK: UI PROPERTY
-  private let textField: UITextField = UITextField()
-  private let clearButton: UIButton = UIButton().then {
-    $0.setImage(.AppImage.delete, for: .normal)
-    $0.tintColor = .AppColor.appGrey70
-  }
-  
-  private let securityButton: UIButton = UIButton().then {
-    $0.setImage(.AppImage.showOff, for: .normal)
-    $0.setImage(.AppImage.showOn, for: .selected)
-  }
-  
-  private lazy var textButton: UIButton = UIButton().then {
-    $0.setTitle(type.buttonTitle, for: .normal)
-    $0.setTitleColor(.AppColor.appBlack, for: .normal)
-    $0.titleLabel?.font = .AppFont.Bold_10
-  }
-  
-  // MARK: INITIALIZE
-  public init(
-    _ type: DefaultTextFieldType,
-    keyboardType: UIKeyboardType = .default
-  ) {
-    self.type = type
-    self.keyboardType = keyboardType
-    self.disposeBag = .init()
-    super.init(frame: .zero)
-    self.setupSubViews()
-    self.setupConfiguration()
-    self.setupBindings()
-    self.setupGeustures()
-  }
-  
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  /// DefaultTextField의 text값을 업데이트 합니다.
-  public func updateText(text: String) {
-    self.textField.text = text
-    self.currentText.accept(text)
-  }
+	
+	// MARK: INPUT PROPERTY
+	private let type: DefaultTextFieldType
+	private let keyboardType: UIKeyboardType
+	
+	// MARK: PROPERTY
+	private let disposeBag: DisposeBag
+	
+	// MARK: UI PROPERTY
+	private let textField: UITextField = UITextField()
+	private let clearButton: UIButton = UIButton().then {
+		$0.setImage(.AppImage.delete, for: .normal)
+		$0.tintColor = .AppColor.appGrey70
+	}
+	
+	private let securityButton: UIButton = UIButton().then {
+		$0.setImage(.AppImage.showOff, for: .normal)
+		$0.setImage(.AppImage.showOn, for: .selected)
+	}
+	
+	private let customView: UIView
+	private var customTypePlaceHolder: String?
+	// MARK: INITIALIZE
+	public init(
+		_ type: DefaultTextFieldType,
+		keyboardType: UIKeyboardType = .default,
+		customView: UIView = UIView(),
+		customTypePlaceHolder: String? = nil
+	) {
+		self.type = type
+		self.keyboardType = keyboardType
+		self.customView = customView
+		self.customTypePlaceHolder = customTypePlaceHolder
+		self.disposeBag = .init()
+		super.init(frame: .zero)
+		self.setupSubViews()
+		self.setupConfiguration()
+		self.setupBindings()
+		self.setupGeustures()
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	/// DefaultTextField의 text값을 업데이트 합니다.
+	public func updateText(text: String) {
+		self.textField.text = text
+		self.currentText.accept(text)
+	}
 }
 
 // MARK: - PRIVATE METHOD
 private extension DefaultTextField {
-  
-  /// DefaultTextField의 SubView들을 관리합니다
-  func setupSubViews() {
-    addSubview(textField)
-    switch type {
-    case .email, .name:
-      addSubview(clearButton)
-    case .password:
-      addSubview(securityButton)
-      addSubview(clearButton)
-    case .emailAuthCode:
-      addSubview(textButton)
-    }
-    
-    setupConstrains()
-  }
-  
-  /// DefaultTextField의 SubView의 오토레이아웃을 정의합니다.
-  func setupConstrains() {
-    snp.makeConstraints { make in
-      make.height.equalTo(Metric.height)
-    }
-    
-    switch type {
-    case .email, .name:
-      clearButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
-        make.centerY.equalToSuperview()
-        make.size.equalTo(Metric.clearButtonSize)
-      }
-      
-      textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
-        make.trailing.equalTo(clearButton.snp.leading).offset(Metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
-      }
-
-    case .password:
-      clearButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
-        make.centerY.equalToSuperview()
-        make.size.equalTo(Metric.clearButtonSize)
-      }
-      
-      securityButton.snp.makeConstraints { make in
-        make.trailing.equalTo(clearButton.snp.leading).offset(Metric.securitRightMargin)
-        make.centerY.equalToSuperview()
-        make.size.equalTo(Metric.securityButtonSize)
-      }
-      
-      textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
-        make.trailing.equalTo(securityButton.snp.leading).offset(Metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
-      }
-
-    case .emailAuthCode:
-      textButton.snp.makeConstraints { make in
-        make.trailing.equalToSuperview().offset(Metric.textButtonRightMargin)
-        make.verticalEdges.equalToSuperview().inset(Metric.textButtonVerticalMargin)
-        make.width.equalTo(textButton.intrinsicContentSize.width)
-      }
-      
-      textField.snp.makeConstraints { make in
-        make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
-        make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
-        make.trailing.equalTo(textButton.snp.leading).offset(Metric.textFieldRightMargin)
-        make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
-      }
-    }
-  }
-  
-  /// DefaultTextField의 타입에 따른 이미지를 정의합니다.
-  func setupConfiguration() {
-    makeCornerRadius(16)
-		backgroundColor = ColorSet.baseBackgroundColor
-    
-		makeBorder(borderColor: .AppColor.appWarning)
+	
+	/// DefaultTextField의 SubView들을 관리합니다
+	func setupSubViews() {
+		addSubview(textField)
+		switch type {
+		case .email, .name:
+			addSubview(clearButton)
+		case .password:
+			addSubview(securityButton)
+			addSubview(clearButton)
+		case .custom:
+			addSubview(customView)
+		}
 		
-    textField.keyboardType = keyboardType
-    textField.placeholder = type.placeHolder
+		setupConstrains()
+	}
+	
+	/// DefaultTextField의 SubView의 오토레이아웃을 정의합니다.
+	func setupConstrains() {
+		snp.makeConstraints { make in
+			make.height.equalTo(Metric.height)
+		}
+		
+		switch type {
+		case .email, .name:
+			clearButton.snp.makeConstraints { make in
+				make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
+				make.centerY.equalToSuperview()
+				make.size.equalTo(Metric.clearButtonSize)
+			}
+			
+			textField.snp.makeConstraints { make in
+				make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+				make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+				make.trailing.equalTo(clearButton.snp.leading).offset(Metric.textFieldRightMargin)
+				make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
+			}
+			
+		case .password:
+			clearButton.snp.makeConstraints { make in
+				make.trailing.equalToSuperview().offset(Metric.clearButtonRightMargin)
+				make.centerY.equalToSuperview()
+				make.size.equalTo(Metric.clearButtonSize)
+			}
+			
+			securityButton.snp.makeConstraints { make in
+				make.trailing.equalTo(clearButton.snp.leading).offset(Metric.securitRightMargin)
+				make.centerY.equalToSuperview()
+				make.size.equalTo(Metric.securityButtonSize)
+			}
+			
+			textField.snp.makeConstraints { make in
+				make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+				make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+				make.trailing.equalTo(securityButton.snp.leading).offset(Metric.textFieldRightMargin)
+				make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
+			}
+			
+		case .custom:
+			customView.snp.makeConstraints { make in
+				make.trailing.equalToSuperview().offset(Metric.customViewRightMargin)
+				make.verticalEdges.equalToSuperview().inset(Metric.customViewVerticalMargin)
+				make.width.equalTo(customView.intrinsicContentSize.width)
+			}
+			
+			textField.snp.makeConstraints { make in
+				make.top.equalToSuperview().offset(Metric.textFieldTopMargin)
+				make.leading.equalToSuperview().offset(Metric.textFieldLeftMargin)
+				make.trailing.equalTo(customView.snp.leading).offset(Metric.textFieldRightMargin)
+				make.bottom.equalToSuperview().offset(Metric.textFieldBottomMargin)
+			}
+		}
+	}
+	
+	/// DefaultTextField의 타입에 따른 이미지를 정의합니다.
+	func setupConfiguration() {
+		makeCornerRadius(16)
+		backgroundColor = ColorSet.baseBackgroundColor
+		
+		// 초기 값 세팅
+		makeBorder(borderColor: .clear)
+		
+		switch type {
+		case .custom:
+			textField.placeholder = customTypePlaceHolder
+		default:
+			textField.placeholder = type.placeHolder
+		}
+		
+		textField.keyboardType = keyboardType
 		textField.textColor = ColorSet.textFieldColor
 		textField.tintColor = ColorSet.textFieldColor
 		textField.font = Font.textFieldFont
-    textField.isSecureTextEntry = type.security
-  }
-  
-  /// DefaultTextField의 Binding을 정의합니다.
-  func setupBindings() {
-    textField.rx.text
-      .map { $0 ?? "" }
-      .asDriver(onErrorJustReturn: "")
-      .drive(onNext: { [weak self] text in
-        self?.currentText.accept(text)
-      }).disposed(by: disposeBag)
-  }
-  
-  /// DefaultTextField의 CornerRadius 및 Gesture를 정의합니다.
-  func setupGeustures() {
-    clearButton.rx.tap
-      .throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
-      .bind { [weak self] in
-        self?.textField.text = ""
-        self?.currentText.accept("")
-      }.disposed(by: disposeBag)
-    
-    securityButton.rx.tap
-      .throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
-      .bind { [weak self] in
-        self?.securityButton.isSelected.toggle()
-        self?.textField.isSecureTextEntry.toggle()
-      }.disposed(by: disposeBag)
-    
-    textButton.rx.tap
-      .throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
-      .bind { [weak self] in
-        self?.didTapTextButton?()
-      }.disposed(by: disposeBag)
-  }
+		textField.isSecureTextEntry = type.security
+	}
+	
+	/// DefaultTextField의 Binding을 정의합니다.
+	func setupBindings() {
+		textField.rx.text
+			.map { $0 ?? "" }
+			.asDriver(onErrorJustReturn: "")
+			.drive(onNext: { [weak self] text in
+				self?.currentText.accept(text)
+			}).disposed(by: disposeBag)
+	}
+	
+	/// DefaultTextField의 CornerRadius 및 Gesture를 정의합니다.
+	func setupGeustures() {
+		clearButton.rx.tap
+			.throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+			.bind { [weak self] in
+				self?.textField.text = ""
+				self?.currentText.accept("")
+			}.disposed(by: disposeBag)
+		
+		securityButton.rx.tap
+			.throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+			.bind { [weak self] in
+				self?.securityButton.isSelected.toggle()
+				self?.textField.isSecureTextEntry.toggle()
+			}.disposed(by: disposeBag)
+	}
 }


### PR DESCRIPTION
### 배경
DefaultTextField에서 몇몇 경우는 특정해 타입으로 지정할 수 있지만, 모든 상황을 컨트롤하기에는 유지보수성 측면에서 떨어진다고 판단.
상황이 변하는 경우는 `DefaultTextField`를 외부에서 관리하는것이 맞다고 판단했기에 외부에서 `UIView`를 주입할 수 있도록 구현

### 변경사항
1. 'emailAuthCode' 타입 삭제
> * 타이머가 들어가며, 외부에서 타이머를 관리하는게 맞다고 판단
> * CustomType으로 변경됩니다.

2. 'DefaultTextField' 생성자 변경
> * 'custom' 타입이 추가됨에 따라, 우측 화면을 결정하게 될 `UIView`와 placeHolder 적용을 위한 `String`을 추가로 주입받을 수 있습니다.
> * 모두 기본 타입이 지정되어 있기 때문에, 기존처럼 타입만 지정해줘도 무관합니다.

### 적용방법

``` swift
final class ViewController: UIViewController {
	
	private let timerLabel: UILabel = UILabel().then {
		$0.text = "3분 37초"
	}
	
	private lazy var customTextField: DefaultTextField = DefaultTextField(
		.custom,
		customView: timerLabel,
		customTypePlaceHolder: "이메일 인증"
	)
	
	// 코드 생략
}
```

### 결과
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/5196876d-8df9-4ddb-9aa4-c34d42812507">