### PR TITLE
`TwoButton` 추가

### DIFF
--- a/DesignSystem/Sources/Buttons/TwoButton.swift
+++ b/DesignSystem/Sources/Buttons/TwoButton.swift
@@ -1,0 +1,188 @@
+//
+//  TwoButton.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/18.
+//
+
+import UIKit
+
+import ResourceKit
+
+import RxCocoa
+import RxSwift
+
+public final class TwoButton: UIView {
+	
+	public enum TwoButtonSizeType {
+		case equal
+		case leftLarger
+		case rightLarger
+	}
+	
+	public enum ButtonType {
+		case primary
+		case origin
+	}
+	
+	// MARK: - METRIC
+	private enum Metric {
+		static let spacing: CGFloat = 16
+		static let height: CGFloat = 48
+		static let smallButtonWidth: CGFloat = 94
+		
+		static let buttonRadius: CGFloat = 12
+	}
+	
+	// MARK: - TAP ACTION CLOSURE
+	public var didTapLeftButton: (() -> Void)?
+	public var didTapRightButton: (() -> Void)?
+	
+	// MARK: - CONFIGURE PROPERTY
+	private let sizeType: TwoButtonSizeType
+	private let buttonType: (left: ButtonType, right: ButtonType)
+	private let leftButtonTitle: String
+	private let rightButtonTitle: String
+	
+	private let disposeBag: DisposeBag
+	
+	// MARK: - UI PROPERTY
+	private let leftButton: UIButton = UIButton(type: .system)
+	private let rightButton: UIButton = UIButton(type: .system)
+	
+	private lazy var buttonStackView: UIStackView = UIStackView(
+		arrangedSubviews: [
+			leftButton,
+			rightButton
+		]
+	).then {
+		$0.axis = .horizontal
+		$0.distribution = .fillEqually
+		$0.spacing = Metric.spacing
+	}
+	
+	public init(
+		sizeType: TwoButtonSizeType = .equal,
+		buttonType: (left: ButtonType, right: ButtonType) = (left: .origin, right: .primary),
+		leftButtonTitle: String,
+		rightButtonTitle: String
+	) {
+		self.sizeType = sizeType
+		self.buttonType = buttonType
+		self.leftButtonTitle = leftButtonTitle
+		self.rightButtonTitle = rightButtonTitle
+		self.disposeBag = .init()
+		super.init(frame: .zero)
+		setupViewConfigure()
+		setupViews()
+		setupGestures()
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+// MARK: - PRIVATE EXTENSION
+private extension TwoButton {
+	func setupViewConfigure() {
+		// MARK: LEFT BUTTON
+		let leftButtonType = buttonType.left
+		switch leftButtonType {
+		case .origin:
+			leftButton.backgroundColor = AppTheme.Color.white
+			leftButton.makeCornerRadiusWithBorder(Metric.buttonRadius)
+			leftButton.setTitle(leftButtonTitle, for: .normal)
+			leftButton.tintColor = AppTheme.Color.grey40
+			leftButton.titleLabel?.font = AppTheme.Font.Bold_12
+		case .primary:
+			leftButton.backgroundColor = AppTheme.Color.primary
+			leftButton.makeCornerRadius(Metric.buttonRadius)
+			leftButton.setTitle(leftButtonTitle, for: .normal)
+			leftButton.tintColor = AppTheme.Color.white
+			leftButton.titleLabel?.font = AppTheme.Font.Bold_16
+		}
+		
+		// MARK: RIGHT BUTTON
+		let rightButtonType = buttonType.right
+		switch rightButtonType {
+		case .origin:
+			rightButton.backgroundColor = AppTheme.Color.white
+			rightButton.makeCornerRadiusWithBorder(Metric.buttonRadius)
+			rightButton.setTitle(rightButtonTitle, for: .normal)
+			rightButton.tintColor = AppTheme.Color.grey40
+			rightButton.titleLabel?.font = AppTheme.Font.Bold_12
+		case .primary:
+			rightButton.backgroundColor = AppTheme.Color.primary
+			rightButton.makeCornerRadius(Metric.buttonRadius)
+			rightButton.setTitle(rightButtonTitle, for: .normal)
+			rightButton.tintColor = AppTheme.Color.white
+			rightButton.titleLabel?.font = AppTheme.Font.Bold_16
+		}
+	}
+	
+	func setupViews() {
+		switch sizeType {
+		case .equal:
+			addSubview(buttonStackView)
+		case .leftLarger, .rightLarger:
+			addSubview(leftButton)
+			addSubview(rightButton)
+		}
+		
+		setupConstraints()
+	}
+	
+	func setupConstraints() {
+		snp.makeConstraints { make in
+			make.height.equalTo(Metric.height)
+		}
+		
+		switch sizeType {
+		case .equal:
+			buttonStackView.snp.makeConstraints { make in
+				make.edges.equalToSuperview()
+			}
+		case .leftLarger:
+			leftButton.snp.makeConstraints { make in
+				make.verticalEdges.equalToSuperview()
+				make.leading.equalToSuperview()
+			}
+			
+			rightButton.snp.makeConstraints { make in
+				make.verticalEdges.equalToSuperview()
+				make.leading.equalTo(leftButton.snp.trailing).offset(Metric.spacing)
+				make.trailing.equalToSuperview()
+				make.width.equalTo(Metric.smallButtonWidth)
+			}
+		case .rightLarger:
+			leftButton.snp.makeConstraints { make in
+				make.verticalEdges.equalToSuperview()
+				make.leading.equalToSuperview()
+				make.width.equalTo(Metric.smallButtonWidth)
+			}
+			
+			rightButton.snp.makeConstraints { make in
+				make.verticalEdges.equalToSuperview()
+				make.leading.equalTo(leftButton.snp.trailing).offset(Metric.spacing)
+				make.trailing.equalToSuperview()
+			}
+		}
+	}
+	
+	func setupGestures() {
+		leftButton.rx.tap
+			.bind { [weak self] in
+				guard let self else { return }
+				self.didTapLeftButton?()
+			}
+			.disposed(by: disposeBag)
+		
+		rightButton.rx.tap
+			.bind { [weak self] in
+				guard let self else { return }
+				self.didTapRightButton?()
+			}
+			.disposed(by: disposeBag)
+	}
+}


### PR DESCRIPTION
### 배경
1. 두 개의 버튼이 가로로 정렬되어 있는 디자인 요구
2. 두 개의 버튼 사이즈 및 속성이 다르게 필요

### 적용사항
1. TwoButtonSizeType
> * 버튼이 배치 될 때 사이즈 결정을 위한 타입
> * `equal` 두 버튼의 사이즈가 같음
> * `leftLarger` 좌측 버튼 사이즈가 큼
> * `rightLarger` 우측 버튼 사이즈가 큼

2. ButtonType
> * 버튼의 스타일을 결정하는 타입
> * `origin` 
>> * background: white
>> * border: grey40
> * `primary` 
>> * background: primary

### 사용 방법

``` swift
final class ViewController: UIViewController {
  private let twoButtonView: TwoButton = TwoButton(
    sizeType: .rightLarger,
    buttonType: (.origin, .primary),
    leftButtonTitle: "선택 취소",
    rightButtonTitle: "검색"
  )
 
  // 코드 생략
  
  private func setupLayouts() {
    twoButtonView.snp.makeConstraints { make in
      make.centerY.equalToSuperview()
      make.horizontalEdges.equalToSuperview().inset(20)
    }
  }
}
```

### 결과

equal | leftLarger | rightLarger
--- | --- | ---
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/b212687c-105d-4169-b380-8f899b281ac4"> | <img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/ba04fa3f-d770-4aa7-8da6-2c35e88582a4"> | <img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/7d236741-7064-4984-a873-ed164ec3d98e">