### PR TITLE
UIButton throttle 적용 부분 rx.touchHandler()로 변경 및 기존 클로저로 액션 주입 부분 Reactive Extension으로 변경

### DIFF
--- a/DesignSystem/Sources/Buttons/Reactive+Extension/Button+Reactive+Extensions.swift
+++ b/DesignSystem/Sources/Buttons/Reactive+Extension/Button+Reactive+Extensions.swift
@@ -1,0 +1,31 @@
+//
+//  Button+Reactive+Extensions.swift
+//  DesignSystem
+//
+//  Created by 구본의 on 2023/11/18.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UIButton {
+	public enum ButtonThrottleDuration: Int {
+		case low = 300
+		case middle = 500
+		case high = 750
+	}
+	
+	public func touchHandler(
+		throttleDuration: ButtonThrottleDuration = .low
+	) -> ControlEvent<Void> {
+		let event = base.rx.tap
+			.throttle(
+				.milliseconds(throttleDuration.rawValue),
+				latest: false, 
+				scheduler: MainScheduler.instance
+			)
+		return ControlEvent(events: event)
+	}
+}

--- a/DesignSystem/Sources/Buttons/TwoButton.swift
+++ b/DesignSystem/Sources/Buttons/TwoButton.swift
@@ -35,8 +35,8 @@ public final class TwoButton: UIView {
 	}
 	
 	// MARK: - TAP ACTION CLOSURE
-	public var didTapLeftButton: (() -> Void)?
-	public var didTapRightButton: (() -> Void)?
+	fileprivate var didTapLeftButton: PublishSubject<Void> = .init()
+	fileprivate var didTapRightButton: PublishSubject<Void> = .init()
 	
 	// MARK: - CONFIGURE PROPERTY
 	private let sizeType: TwoButtonSizeType
@@ -171,18 +171,22 @@ private extension TwoButton {
 	}
 	
 	func setupGestures() {
-		leftButton.rx.tap
-			.bind { [weak self] in
-				guard let self else { return }
-				self.didTapLeftButton?()
-			}
+		leftButton.rx.touchHandler()
+			.bind(to: didTapLeftButton)
 			.disposed(by: disposeBag)
 		
-		rightButton.rx.tap
-			.bind { [weak self] in
-				guard let self else { return }
-				self.didTapRightButton?()
-			}
+		rightButton.rx.touchHandler()
+			.bind(to: didTapRightButton)
 			.disposed(by: disposeBag)
+	}
+}
+
+extension Reactive where Base: TwoButton {
+	public var tapLeftButton: ControlEvent<Void> {
+		ControlEvent(events: base.didTapLeftButton.asObservable())
+	}
+	
+	public var tapRightButton: ControlEvent<Void> {
+		ControlEvent(events: base.didTapRightButton.asObservable())
 	}
 }

--- a/DesignSystem/Sources/TextFields/DefaultTextField.swift
+++ b/DesignSystem/Sources/TextFields/DefaultTextField.swift
@@ -20,7 +20,6 @@ public class DefaultTextField: UIView {
 	public let currentText: BehaviorRelay<String> = BehaviorRelay<String>(value: "")
 	
 	// MARK: ACTION CLOSURE
-	public var didTapTextButton: (() -> Void)?
 	public var currentState: DefaultTextFieldState = .normal {
 		didSet {
 			switch currentState {
@@ -264,15 +263,13 @@ private extension DefaultTextField {
 	
 	/// DefaultTextField의 CornerRadius 및 Gesture를 정의합니다.
 	func setupGeustures() {
-		clearButton.rx.tap
-			.throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+		clearButton.rx.touchHandler()
 			.bind { [weak self] in
 				self?.textField.text = ""
 				self?.currentText.accept("")
 			}.disposed(by: disposeBag)
 		
-		securityButton.rx.tap
-			.throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+		securityButton.rx.touchHandler()
 			.bind { [weak self] in
 				self?.securityButton.isSelected.toggle()
 				self?.textField.isSecureTextEntry.toggle()


### PR DESCRIPTION
### 배경
1. 버튼 제스처 정의 시 tap.throttle()을 중복적으로 사용
2. 외부에서 클로저 주입하는 부분이 코드내에서 제스처를 정의하는 부분과 통일성이 떨어진다고 생각

### 변경사항
1. throttle
> * `ButtonThrottleDuration`을 주입할 수 있는 touchHandler(throttleDuration: ) 메소드 생성

2. 클로저 삭제
> * 각각 Reactive Extension으로 수정해 rx.leftButton과 같이 접근 가능

### 적용 방법

``` swift
import DesignSystem

final class ViewController: UIViewController {
  // 일반 버튼
  private let button = UIButton()

  // 디자인 시스템에 있는 네비바입니다.
  private let navigationBar = NavigationBar()
  
  private func setupGestures() {
    // 일반적인 버튼에 tap제스처를 정의하던 부분이 수정되었습니다.
    // 기존 사용성 개선을 위해 throttle을 추가했던 코드를 더이상 작성하지 않아도 됩니다.
    button.rx.touchHandler()
      .bind {
        // 코드 생략
      }.disposed(by: disposeBag)

    // 디자인 시스템에서 기존 didTap 클로저를 더 이상 정의하지 않습니다.
   // 각 디자인 시스템에 정의되어 있는 extension을 확인 해주세요
    navigationBar.rx.tapLeftButton
      .bind {
        // 코드 생략
      }.disposed(by: disposeBag)
  }
}
```