### PR TITLE
NavigationBar Bottom GuideLine 추가

### DIFF
--- a/DesignSystem/Sources/NavigationBar/NavigationBar.swift
+++ b/DesignSystem/Sources/NavigationBar/NavigationBar.swift
@@ -44,6 +44,8 @@ public class NavigationBar: UIView {
 		
 		static let navigationTitleTopMargin: CGFloat = 14
 		static let navigationTitleBottomMargin: CGFloat = -15
+		
+		static let guideLineHeight: CGFloat = 1
 	}
 	
 	// MARK: Font
@@ -56,6 +58,7 @@ public class NavigationBar: UIView {
 		static let backgroundColor: UIColor = AppTheme.Color.white
 		static let navigationTitleColor: UIColor = AppTheme.Color.black
 		static let navigationLeftButtonColor: UIColor = AppTheme.Color.black
+		static let guideLineColor: UIColor = AppTheme.Color.grey70
 	}
 	
 	// MARK: - TAP SUBJECT
@@ -64,18 +67,24 @@ public class NavigationBar: UIView {
 	// MARK: - PROPERTY
 	private let navigationType: NavigationType
 	private let navigationTitle: String
+	private let hasGuideLine: Bool
 	private let disposeBag: DisposeBag
 	
 	private let navigationLeftButton: UIButton = UIButton(type: .system)
 	private let navigationTitleLabel: UILabel = UILabel()
+	private let guideLineView: UIView = UIView().then {
+		$0.backgroundColor = ColorSet.guideLineColor
+	}
 	
 	// MARK: - Initialize
 	public init(
 		_ navigationType: NavigationType = .none,
-		title: String = ""
+		title: String = "",
+		hasGuideLine: Bool = false
 	) {
 		self.navigationType = navigationType
 		self.navigationTitle = title
+		self.hasGuideLine = hasGuideLine
 		self.disposeBag = .init()
 		super.init(frame: .zero)
 		setupConfigure()
@@ -109,6 +118,10 @@ private extension NavigationBar {
 		addSubview(navigationLeftButton)
 		addSubview(navigationTitleLabel)
 		
+		if hasGuideLine {
+			addSubview(guideLineView)
+		}
+		
 		setupConstraints()
 	}
 	
@@ -127,6 +140,14 @@ private extension NavigationBar {
 			make.top.equalToSuperview().offset(Metric.navigationTitleTopMargin)
 			make.bottom.equalToSuperview().offset(Metric.navigationTitleBottomMargin)
 			make.centerX.equalToSuperview()
+		}
+		
+		if hasGuideLine {
+			guideLineView.snp.makeConstraints { make in
+				make.horizontalEdges.equalToSuperview()
+				make.bottom.equalToSuperview()
+				make.height.equalTo(Metric.guideLineHeight)
+			}
 		}
 	}
 	


### PR DESCRIPTION
### 배경
네비게이션 바 하단 가이드라인의 필요성
없는 경우, 있는 경우 별도 구분 필요

### 변경사항
1. 생성자에서 `hasGuideLine`을 받음
> * 기본 값은 false
> * true로 적용 시, GuideLine 추가

### 적용 방법
``` swift
import DesignSystem

final class ViewController: UIViewController {
  private let navigationBar = NavigationBar(title: "네비게이션", hasGuideLine: true)

  // 코드 생략
}
```

### 결과
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/ffe88999-7ce0-4323-9fba-3af643711c22">