### PR TITLE
로그인 화면에서 메인화면으로 화면전환을 위한 로직구현

### DIFF
--- a/Feature/Login/Sources/Email/Login/EmailLogin/EmailLoginViewController.swift
+++ b/Feature/Login/Sources/Email/Login/EmailLogin/EmailLoginViewController.swift
@@ -356,8 +356,8 @@ private extension EmailLoginViewController {
 				guard let isCompleted else { return }
 				
 				if isCompleted {
-					let vc = MainTabBarController()
-					self.changeRootViewController(vc)
+					let mainTabBarController: MainTabBarController = MainTabBarController()
+					self.changeRootViewController(mainTabBarController)
 				} else {
 					headerSlideView.startAnimation(at: self)
 				}

--- a/Feature/Login/Sources/Email/Login/EmailLogin/EmailLoginViewController.swift
+++ b/Feature/Login/Sources/Email/Login/EmailLogin/EmailLoginViewController.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 import DesignSystem
+import Main
 import ResourceKit
+import UtilityKit
 
 import RxSwift
 import SnapKit
@@ -354,7 +356,8 @@ private extension EmailLoginViewController {
 				guard let isCompleted else { return }
 				
 				if isCompleted {
-					//TODO 성공시: 홈화면 연결 로직
+					let vc = MainTabBarController()
+					self.changeRootViewController(vc)
 				} else {
 					headerSlideView.startAnimation(at: self)
 				}

--- a/Feature/Login/Sources/Email/Signup/EmailSignupPhone/EmailSignupPhoneViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupPhone/EmailSignupPhoneViewController.swift
@@ -184,8 +184,8 @@ private extension EmailSignupPhoneViewController {
 				guard let self else { return }
 												
 				if isCompleted {
-					let vc = MainTabBarController()
-					self.changeRootViewController(vc)
+					let mainTabBarController: MainTabBarController = MainTabBarController()
+					self.changeRootViewController(mainTabBarController)
 				} else {
 					let alert = UIAlertController(
 						title: TextSet.failureAlertTitleText,

--- a/Feature/Login/Sources/Email/Signup/EmailSignupPhone/EmailSignupPhoneViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupPhone/EmailSignupPhoneViewController.swift
@@ -9,7 +9,9 @@ import Foundation
 import UIKit
 
 import DesignSystem
+import Main
 import ResourceKit
+import UtilityKit
 
 import RxSwift
 import SnapKit
@@ -180,21 +182,10 @@ private extension EmailSignupPhoneViewController {
 			.compactMap { $0 }
 			.subscribe(onNext: { [weak self] isCompleted in
 				guard let self else { return }
-								
+												
 				if isCompleted {
-					// MARK: - TODO 홈화면으로 바로 이동하는 로직으로 변경
-					let alert = UIAlertController(
-						title: "회원가입 완료", message: "이메일 로그인 화면으로 이동합니다", preferredStyle: .alert)
-					let success = UIAlertAction(title: "확인", style: .default) { _ in
-						guard let viewControllerStack = self.navigationController?.viewControllers else { return }
-						for viewController in viewControllerStack {
-							if let emailLoginView = viewController as? EmailLoginViewController {
-								self.navigationController?.popToViewController(emailLoginView, animated: true)
-							}
-						}
-					}
-					alert.addAction(success)
-					present(alert, animated: true)
+					let vc = MainTabBarController()
+					self.changeRootViewController(vc)
 				} else {
 					let alert = UIAlertController(
 						title: TextSet.failureAlertTitleText,

--- a/UtilityKit/Sources/Extensions/UIViewController+Extension.swift
+++ b/UtilityKit/Sources/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  Uiviewcontoller+Extension.swift
+//  UtilityKit
+//
+//  Created by 김동겸 on 12/28/23.
+//
+
+import Foundation
+import UIKit
+
+public extension UIViewController {
+	/// UIWindow의 rootViewController를 변경하여 화면전환 메소드
+	func changeRootViewController(_ viewControllerToPresent: UIViewController) {
+		if let window = UIApplication.shared.windows.first {
+			window.rootViewController = viewControllerToPresent
+			UIView.transition(
+				with: window, duration: 0.5, 
+				options: .transitionCrossDissolve,
+				animations: nil
+			)
+		} else {
+			viewControllerToPresent.modalPresentationStyle = .overFullScreen
+			self.present(viewControllerToPresent, animated: true, completion: nil)
+		}
+	}
+}


### PR DESCRIPTION
### 배경
1. 이메일 로그인화면에서 로그인 성공시 메인화면으로 전환
2. 이메일 회원가입화면에서 회원가입 성공시 메인화면으로 전환

### 변경사항
1. `func changeRootViewController()`추가
> * UIWindow의 rootViewController를 변경합니다.
> * UtilityKit의 UIViewController+Extension 내부에 존재합니다.

### 적용방법
``` swift
import Main
import UtilityKit

final class FirstViewController: UIViewController {
  // 코드 생략
  
  private func changeRootViewController() {
    let secondVC: UIViewController = SecondViewController()
    self.changeRootViewController(secondVC)
  }
}
```

### 결과
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/86482563/03cfbcd0-9e71-4bd7-b666-faf78db451f8">