### PR TITLE
프로필 이미지 수정 시 블러 처리 적용

### DIFF
--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -198,7 +198,7 @@ private extension EditProfileImageAtSignupViewController {
 	}
 	
 	private func setupImagePinchGesture() {
-		profileImageView.rx.pinchGesture()
+		snapShotAreaView.rx.pinchGesture()
 			.when(.began, .changed, .ended)
 			.share(replay: 1)
 			.subscribe(onNext: { [weak self] recognize in

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -52,6 +52,11 @@ final class EditProfileImageAtSignupViewController: UIViewController {
 		$0.backgroundColor = AppTheme.Color.black
 	}
 	
+	private let blurView: UIVisualEffectView = UIVisualEffectView().then {
+		$0.effect = UIBlurEffect(style: .dark)
+		$0.backgroundColor = UIColor.clear
+	}
+	
 	private let bottomContainerView: UIView = UIView().then {
 		$0.backgroundColor = AppTheme.Color.black.withAlphaComponent(0.7)
 	}
@@ -118,6 +123,7 @@ private extension EditProfileImageAtSignupViewController {
 	func setupViews() {
 		view.addSubview(snapShotAreaView)
 		snapShotAreaView.addSubview(profileImageView)
+		snapShotAreaView.addSubview(blurView)
 		
 		setupConstraints()
 		setNavigationBar()
@@ -134,6 +140,10 @@ private extension EditProfileImageAtSignupViewController {
 		
 		profileImageView.snp.makeConstraints { make in
 			make.edges.equalTo(view.safeAreaLayoutGuide)
+		}
+		
+		blurView.snp.makeConstraints { make in
+			make.edges.equalTo(view.snp.edges)
 		}
 		
 		view.layoutIfNeeded()
@@ -178,6 +188,8 @@ private extension EditProfileImageAtSignupViewController {
 		fillLayer.fillColor = AppTheme.Color.black.cgColor
 		fillLayer.path = outerbezierPath.cgPath
 		maskView.layer.addSublayer(fillLayer)
+		
+		blurView.mask = maskView
 	}
 	
 	func setGuideAreaViews() {
@@ -204,7 +216,7 @@ private extension EditProfileImageAtSignupViewController {
 			.subscribe(onNext: { [weak self] recognize in
 				guard let self = self else { return }
 				switch recognize.state {
-				case .began: print("시작")
+				case .began: self.blurView.effect = nil
 				case .changed:
 					let pinchScale: CGFloat = recognize.scale
 					if self.imageViewScale * pinchScale < Metric.maxScale &&
@@ -217,7 +229,7 @@ private extension EditProfileImageAtSignupViewController {
 					}
 					recognize.scale = 1.0
 				case .ended:
-					print("끝")
+					self.blurView.effect = UIBlurEffect(style: .dark)
 				default: break
 				}
 			}).disposed(by: disposeBag)
@@ -236,6 +248,7 @@ private extension EditProfileImageAtSignupViewController {
 						x: self.profileImageView.center.x,
 						y: self.profileImageView.center.y
 					)
+					self.blurView.effect = nil
 				case .changed:
 					let translation = recognize.translation(in: self.profileImageView)
 					self.profileImageView.center = CGPoint(
@@ -244,6 +257,7 @@ private extension EditProfileImageAtSignupViewController {
 					)
 				case .ended:
 					imageCenterOffset = .zero
+					self.blurView.effect = UIBlurEffect(style: .dark)
 				default: break
 				}
 			}).disposed(by: disposeBag)

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -356,7 +356,7 @@ private extension EditProfileImageAtSignupViewController {
 			$0.setImage(AppTheme.Image.rotateLeft, for: .normal)
 		}
 		
-		let rotatePIButton: UIButton = UIButton(type: .system).then {
+		let rotateResetButton: UIButton = UIButton(type: .system).then {
 			$0.tintColor = AppTheme.Color.white
 			$0.setImage(AppTheme.Image.rotatePI, for: .normal)
 		}
@@ -368,7 +368,7 @@ private extension EditProfileImageAtSignupViewController {
 		
 		let buttonStackView: UIStackView = .init(arrangedSubviews: [
 			rotateLeftButton,
-			rotatePIButton,
+			rotateResetButton,
 			rotateRightButton
 		]).then {
 			$0.distribution = .equalSpacing
@@ -399,16 +399,36 @@ private extension EditProfileImageAtSignupViewController {
 				.offset(Metric.buttonStackViewBottomMargin)
 		}
 		
-		rotateLeftButton.rx.tapGesture()
-			.when(.recognized)
-			.bind { [weak self] _ in
+		rotateLeftButton.rx.touchHandler()
+			.bind { [weak self] in
 				guard let self else { return }
 				self.profileImageView.transform = self.profileImageView.transform.rotated(by: -(.pi / 2.0))
 			}.disposed(by: disposeBag)
 		
-		rotateRightButton.rx.tapGesture()
-			.when(.recognized)
-			.bind { [weak self] _ in
+		rotateResetButton.rx.touchHandler()
+			.bind { [weak self] in
+				guard let self else { return }
+				let radians: CGFloat = atan2(
+					self.profileImageView.transform.b,
+					self.profileImageView.transform.a
+				)
+				let degrees: CGFloat = radians * (180 / .pi)
+				switch degrees {
+				case 45..<135:
+					self.profileImageView.transform = self.profileImageView.transform.rotated(by: -(.pi / 2.0))
+				case 135...180:
+					self.profileImageView.transform = self.profileImageView.transform.rotated(by: .pi)
+				case -180 ..< -135:
+					self.profileImageView.transform = self.profileImageView.transform.rotated(by: -.pi)
+				case -135 ..< -45:
+					self.profileImageView.transform = self.profileImageView.transform.rotated(by: (.pi / 2.0))
+				default:
+					break
+				}
+			}.disposed(by: disposeBag)
+		
+		rotateRightButton.rx.touchHandler()
+			.bind { [weak self] in
 				guard let self else { return }
 				self.profileImageView.transform = self.profileImageView.transform.rotated(by: .pi / 2.0)
 			}.disposed(by: disposeBag)

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -255,11 +255,31 @@ private extension EditProfileImageAtSignupViewController {
 					self.blurView.effect = nil
 					self.snapShotGuideLineMaskLayer.fillColor = AppTheme.Color.black.withAlphaComponent(0.3).cgColor
 				case .changed:
+					let transform: CGAffineTransform = self.profileImageView.transform
 					let translation = recognize.translation(in: self.profileImageView)
-					self.profileImageView.center = CGPoint(
-						x: imageCenterOffset.x + translation.x,
-						y: imageCenterOffset.y + translation.y
-					)
+					if transform.a >= 1.0 && transform.d >= 1.0 {
+						self.profileImageView.center = CGPoint(
+							x: imageCenterOffset.x + translation.x,
+							y: imageCenterOffset.y + translation.y
+						)
+					} else if transform.b >= 1.0 && transform.c <= -1.0 {
+						self.profileImageView.center = CGPoint(
+							x: imageCenterOffset.x - translation.y,
+							y: imageCenterOffset.y + translation.x
+						)
+					} else if transform.a <= -1.0 && transform.d <= -1.0 {
+						self.profileImageView.center = CGPoint(
+							x: imageCenterOffset.x - translation.x,
+							y: imageCenterOffset.y - translation.y
+						)
+					} else if transform.b <= -1.0 && transform.c >= 1.0 {
+						self.profileImageView.center = CGPoint(
+							x: imageCenterOffset.x + translation.y,
+							y: imageCenterOffset.y - translation.x
+						)
+					} else {
+						break
+					}
 				case .ended:
 					imageCenterOffset = .zero
 					self.blurView.effect = UIBlurEffect(style: .dark)

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -225,7 +225,7 @@ private extension EditProfileImageAtSignupViewController {
 	
 	private func setupImagePanGesture() {
 		var imageCenterOffset: CGPoint = .zero
-		profileImageView.rx.panGesture()
+		snapShotAreaView.rx.panGesture()
 			.when(.began, .changed, .ended)
 			.share(replay: 1)
 			.subscribe(onNext: { [weak self] recognize in

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EditProfileImageAtSignupViewController.swift
@@ -57,6 +57,8 @@ final class EditProfileImageAtSignupViewController: UIViewController {
 		$0.backgroundColor = UIColor.clear
 	}
 	
+	private let snapShotGuideLineMaskLayer: CAShapeLayer = .init()
+	
 	private let bottomContainerView: UIView = UIView().then {
 		$0.backgroundColor = AppTheme.Color.black.withAlphaComponent(0.7)
 	}
@@ -152,17 +154,16 @@ private extension EditProfileImageAtSignupViewController {
 	func setupSnapShotGuideLineLayer() {
 		let snapShotFrame: CGRect = snapShotAreaView.frame
 		let snapShotSize: CGSize = snapShotFrame.size
-		let maskLayer = CAShapeLayer()
-		maskLayer.frame = self.profileImageView.bounds
-		maskLayer.fillColor = AppTheme.Color.black.withAlphaComponent(0.3).cgColor
+		snapShotGuideLineMaskLayer.frame = self.profileImageView.bounds
+		snapShotGuideLineMaskLayer.fillColor = UIColor.clear.cgColor
 		let path = UIBezierPath(
 			roundedRect: snapShotFrame,
 			cornerRadius: snapShotSize.width / 2.0
 		)
 		path.append(UIBezierPath(rect: view.bounds))
-		maskLayer.path = path.cgPath
-		maskLayer.fillRule = CAShapeLayerFillRule.evenOdd
-		view.layer.addSublayer(maskLayer)
+		snapShotGuideLineMaskLayer.path = path.cgPath
+		snapShotGuideLineMaskLayer.fillRule = CAShapeLayerFillRule.evenOdd
+		view.layer.addSublayer(snapShotGuideLineMaskLayer)
 	}
 	
 	func setupSnapShowGuideLineBlurLayer() {
@@ -216,7 +217,9 @@ private extension EditProfileImageAtSignupViewController {
 			.subscribe(onNext: { [weak self] recognize in
 				guard let self = self else { return }
 				switch recognize.state {
-				case .began: self.blurView.effect = nil
+				case .began: 
+					self.blurView.effect = nil
+					self.snapShotGuideLineMaskLayer.fillColor = AppTheme.Color.black.withAlphaComponent(0.3).cgColor
 				case .changed:
 					let pinchScale: CGFloat = recognize.scale
 					if self.imageViewScale * pinchScale < Metric.maxScale &&
@@ -230,6 +233,7 @@ private extension EditProfileImageAtSignupViewController {
 					recognize.scale = 1.0
 				case .ended:
 					self.blurView.effect = UIBlurEffect(style: .dark)
+					self.snapShotGuideLineMaskLayer.fillColor = UIColor.clear.cgColor
 				default: break
 				}
 			}).disposed(by: disposeBag)
@@ -249,6 +253,7 @@ private extension EditProfileImageAtSignupViewController {
 						y: self.profileImageView.center.y
 					)
 					self.blurView.effect = nil
+					self.snapShotGuideLineMaskLayer.fillColor = AppTheme.Color.black.withAlphaComponent(0.3).cgColor
 				case .changed:
 					let translation = recognize.translation(in: self.profileImageView)
 					self.profileImageView.center = CGPoint(
@@ -258,6 +263,7 @@ private extension EditProfileImageAtSignupViewController {
 				case .ended:
 					imageCenterOffset = .zero
 					self.blurView.effect = UIBlurEffect(style: .dark)
+					self.snapShotGuideLineMaskLayer.fillColor = UIColor.clear.cgColor
 				default: break
 				}
 			}).disposed(by: disposeBag)

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -323,7 +323,9 @@ private extension EmailSignupNameViewController {
 				useCase: useCase
 			)
 			
-			let signupPhoneVC = EmailSignupPhoneViewController(emailSignupPhoneViewModel: viewModel)
+		let signupPhoneVC: EmailSignupPhoneViewController = EmailSignupPhoneViewController(
+			emailSignupPhoneViewModel: viewModel
+		)
 			navigation.pushViewController(signupPhoneVC, animated: true)
 	}
 }

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -301,7 +301,8 @@ private extension EmailSignupNameViewController {
 	}
 	
 	func pushSignupPhoneViewController(with profileImageData: Data) {
-		if let navigation = self.navigationController as? EmailLoginNavigationController {
+		guard let navigation = self.navigationController 
+						as? EmailLoginNavigationController else { return }
 			navigation.pageController.moveToNextPage()
 			
 			let repository: UsersRepositoryInterface = UsersRepository()
@@ -319,7 +320,6 @@ private extension EmailSignupNameViewController {
 			
 			let signupPhoneVC = EmailSignupPhoneViewController(emailSignupPhoneViewModel: viewModel)
 			navigation.pushViewController(signupPhoneVC, animated: true)
-		}
 	}
 }
 

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -315,7 +315,6 @@ private extension EmailSignupNameViewController {
 			
 			let name: String = emailSignupNameViewModel.nameRelay.value
 			emailSignupNameViewModel.userSignupDTO.userName = name
-			
 			emailSignupNameViewModel.userSignupDTO.profileImg = profileImageData
 			
 			let viewModel: EmailSignupPhoneViewModel = EmailSignupPhoneViewModel(

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -40,6 +40,8 @@ public final class EmailSignupNameViewController: UIViewController {
 		
 		static let nextButtonBottomMargin: CGFloat = 34
 		static let nextButttonBothsides: CGFloat = 24
+		
+		static let profileimageCompressionQuality: CGFloat = 0.5
 	}
 	
 	// MARK: - FONT
@@ -234,7 +236,9 @@ private extension EmailSignupNameViewController {
 						return
 					}
 					
-					guard let profileImageData: Data = profileImage.jpegData(compressionQuality: 0.5) else {
+					guard let profileImageData: Data = profileImage.jpegData(
+						compressionQuality: Metric.profileimageCompressionQuality
+					) else {
 						let alert = UIAlertController(
 							title: TextSet.failureAlertTitleText,
 							message: TextSet.failureAlertMessageText,

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -247,7 +247,8 @@ private extension EmailSignupNameViewController {
 						
 						let failure = UIAlertAction(
 							title: TextSet.failureAlertBtnTitleText,
-							style: .default)
+							style: .default
+						)
 						
 						alert.addAction(failure)
 						present(alert, animated: true)

--- a/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
+++ b/Feature/Login/Sources/Email/Signup/EmailSignupName/EmailSignupNameViewController.swift
@@ -70,9 +70,9 @@ public final class EmailSignupNameViewController: UIViewController {
 		static let navigationBarText: String = "회원가입"
 		static let nameLabelText: String = "이름을 입력해 주세요"
 		static let nextButtonText: String = "다음"
-		static let failureAlertTitleText: String = "실패"
-		static let failureAlertMessageText: String = "프로필 이미지를 다시 선택해 주세요"
-		static let failureAlertBtnTitleText: String = "확인"
+		static let alertTitleText: String = "실패"
+		static let alertMessageText: String = "프로필 이미지를 다시 선택해 주세요"
+		static let alertConfirmButtonTitleText: String = "확인"
 	}
 	
 	// MARK: - PRIVATE PROPERTY
@@ -240,17 +240,17 @@ private extension EmailSignupNameViewController {
 						compressionQuality: Metric.profileimageCompressionQuality
 					) else {
 						let alert = UIAlertController(
-							title: TextSet.failureAlertTitleText,
-							message: TextSet.failureAlertMessageText,
+							title: TextSet.alertTitleText,
+							message: TextSet.alertMessageText,
 							preferredStyle: .alert
 						)
 						
-						let failure = UIAlertAction(
-							title: TextSet.failureAlertBtnTitleText,
+						let confirmButton = UIAlertAction(
+							title: TextSet.alertConfirmButtonTitleText,
 							style: .default
 						)
 						
-						alert.addAction(failure)
+						alert.addAction(confirmButton)
 						present(alert, animated: true)
 						return
 					}


### PR DESCRIPTION
## PR은 내가 작성한 코드를 다른 사람이 보기 때문에 아래 사항을 최대한 구체적으로 작성 해주세요😘

### 1️⃣ 해당 PR을 생성하게 된 배경을 작성 해주세요
> UI 구현의 경우, 피그마 이미지를 여기에 넣어주세요
- 프로필 수정 제스처 동작 시, 블러 이미지 적용
<img height="400" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/be116c50-3c23-4eef-9a1c-3174eb83c1c4">

### 2️⃣ 변경된 사항을 작성 해주세요
> 주요 변경 사항들에 대해 파일, 함수, 변수 등을 작성 해주세요.
- `setupImagePinchGesture ()` 이미지 확대, 축소에 대한 동작입니다.
- `setupImagePanGesture()` 이미지 움직임에 대한 동작입니다.
- 제스처 동작 시, `blurEffect = nil`, `snapShotGuideLineMaskLayer.fillColor = clear`로 적용
- 회전 액션 및 회전 초기화 액션 추가

### 3️⃣ 변경 사항에 대해 적용 방법을 공유해야 되는 경우(ex. DesignSystem) 코드를 통해 사용 방법을 공유 해주세요
> 없을 경우 작성하지 않아도 됩니다.
- 없음

### 4️⃣ 신경 써서 봐야할 파일이 있다면 구체적으로 작성 해주세요
> 특정 파일 또는 코드에서 크로스 체크가 필요한 경우 작성 해주세요.
- `EditProfileImageAtSignupViewController` 클래스 전체

### 5️⃣ 결과를 작성 해주세요
> UI의 경우 실제 화면 캡처 화면을, 추가 해주세요.
> 나머지 경우 'OOO 완료'로 작성 해주세요
- 이미지 수정 시, 블러 처리 완료
- GIF 이미지
<img width="300" alt="image" src="https://github.com/Guboneui/GuestHoust-User/assets/73548875/6261980f-003d-486d-9b7e-fd902b251737">